### PR TITLE
Create instances of a full scene tree node from python scripts

### DIFF
--- a/crescent_py_api/crescent_api.py
+++ b/crescent_py_api/crescent_api.py
@@ -1631,7 +1631,7 @@ class PackedScene:
         self.scene_cache_id = scene_cache_id
         self.path = path
 
-    def create_instance(self):
+    def create_instance(self) -> Node:
         return crescent_api_internal.packed_scene_create_instance(
             scene_cache_id=self.scene_cache_id
         )

--- a/crescent_py_api/crescent_api.py
+++ b/crescent_py_api/crescent_api.py
@@ -1624,3 +1624,18 @@ class GameConfig:
             print(f"Game Config Load Json Decode Error: {e}")
             return {}
         return json_dict
+
+
+class PackedScene:
+    def __init__(self, packed_id: int, path: str):
+        self.packed_id = packed_id
+        self.path = path
+
+
+class SceneUtil:
+    @staticmethod
+    def load_scene(path: str) -> Optional[PackedScene]:
+        packed_id = crescent_api_internal.scene_util_load_scene(path=path)
+        if packed_id < 0:
+            return None
+        return PackedScene(packed_id=packed_id, path=path)

--- a/crescent_py_api/crescent_api.py
+++ b/crescent_py_api/crescent_api.py
@@ -1627,15 +1627,20 @@ class GameConfig:
 
 
 class PackedScene:
-    def __init__(self, packed_id: int, path: str):
-        self.packed_id = packed_id
+    def __init__(self, scene_cache_id: int, path: str):
+        self.scene_cache_id = scene_cache_id
         self.path = path
+
+    def create_instance(self):
+        return crescent_api_internal.packed_scene_create_instance(
+            scene_cache_id=self.scene_cache_id
+        )
 
 
 class SceneUtil:
     @staticmethod
     def load_scene(path: str) -> Optional[PackedScene]:
-        packed_id = crescent_api_internal.scene_util_load_scene(path=path)
-        if packed_id < 0:
+        scene_cache_id = crescent_api_internal.scene_util_load_scene(path=path)
+        if scene_cache_id < 0:
             return None
-        return PackedScene(packed_id=packed_id, path=path)
+        return PackedScene(scene_cache_id=scene_cache_id, path=path)

--- a/crescent_py_api/crescent_api_internal.py
+++ b/crescent_py_api/crescent_api_internal.py
@@ -659,5 +659,9 @@ def game_config_load(path: str, encryption_key="") -> str:
     return '{ "level": 0 }'
 
 
+def packed_scene_create_instance(scene_cache_id: int):
+    pass
+
+
 def scene_util_load_scene(path: str) -> int:
     return 0

--- a/crescent_py_api/crescent_api_internal.py
+++ b/crescent_py_api/crescent_api_internal.py
@@ -657,3 +657,7 @@ def game_config_save(path: str, data_json: str, encryption_key="") -> bool:
 
 def game_config_load(path: str, encryption_key="") -> str:
     return '{ "level": 0 }'
+
+
+def scene_util_load_scene(path: str) -> int:
+    return 0

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(${PROJECT_NAME} STATIC
         src/core/engine_context.c
         src/core/node_event.c
         src/core/world.c
+        src/core/scene/scene_template_cache.c
         src/core/scene/scene_manager.c
         src/core/scene/scene_utils.c
         src/core/scripting/script_context.c

--- a/engine/src/core/camera/camera.c
+++ b/engine/src/core/camera/camera.c
@@ -28,11 +28,11 @@ void cre_camera2d_follow_entity(CRECamera2D* camera2D, Entity entity) {
     camera2D->entityFollowing = entity;
     camera2D->mode = CreCameraMode_FOLLOW_ENTITY;
     // Register to entity events
-    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE);
+    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE);
     if (nodeComponent != NULL) {
         se_event_register_observer(&nodeComponent->onSceneTreeExit, &camera2D->onEntityExitSceneObserver);
     }
-    Transform2DComponent* transform2DComponent = (Transform2DComponent *) component_manager_get_component_unsafe(entity, ComponentDataIndex_TRANSFORM_2D);
+    Transform2DComponent* transform2DComponent = (Transform2DComponent *) component_manager_get_component_unchecked(entity, ComponentDataIndex_TRANSFORM_2D);
     if (transform2DComponent != NULL) {
         se_event_register_observer(&transform2DComponent->onTransformChanged, &camera2D->onEntityTransformChangeObserver);
         // Trigger update right away so camera can be in position
@@ -45,11 +45,11 @@ void cre_camera2d_unfollow_entity(CRECamera2D* camera2D, Entity entity) {
         camera2D->entityFollowing = NULL_ENTITY;
         camera2D->mode = CreCameraMode_MANUAL;
         // Unregister from entity events
-        NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE);
+        NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE);
         if (nodeComponent != NULL) {
             se_event_unregister_observer(&nodeComponent->onSceneTreeExit, &camera2D->onEntityExitSceneObserver);
         }
-        Transform2DComponent* transform2DComponent = (Transform2DComponent *) component_manager_get_component_unsafe(entity, ComponentDataIndex_TRANSFORM_2D);
+        Transform2DComponent* transform2DComponent = (Transform2DComponent *) component_manager_get_component_unchecked(entity, ComponentDataIndex_TRANSFORM_2D);
         if (transform2DComponent != NULL) {
             se_event_unregister_observer(&transform2DComponent->onTransformChanged,
                                          &camera2D->onEntityTransformChangeObserver);

--- a/engine/src/core/ecs/component/component.c
+++ b/engine/src/core/ecs/component/component.c
@@ -83,7 +83,7 @@ void* component_manager_get_component(Entity entity, ComponentDataIndex index) {
     return component;
 }
 
-void* component_manager_get_component_unsafe(Entity entity, ComponentDataIndex index) {
+void* component_manager_get_component_unchecked(Entity entity, ComponentDataIndex index) {
     return component_array_get_component(componentManager->entityComponentArrays[entity], index);
 }
 

--- a/engine/src/core/ecs/component/component.h
+++ b/engine/src/core/ecs/component/component.h
@@ -47,7 +47,7 @@ typedef struct ComponentEntityUpdatePayload {
 void component_manager_initialize();
 void component_manager_finalize();
 void* component_manager_get_component(Entity entity, ComponentDataIndex index);
-void* component_manager_get_component_unsafe(Entity entity, ComponentDataIndex index); // No check, will probably consolidate later...
+void* component_manager_get_component_unchecked(Entity entity, ComponentDataIndex index); // No check, will probably consolidate later...
 void component_manager_set_component(Entity entity, ComponentDataIndex index, void* component);
 void component_manager_remove_component(Entity entity, ComponentDataIndex index);
 void component_manager_remove_all_components(Entity entity);

--- a/engine/src/core/ecs/ecs_manager.c
+++ b/engine/src/core/ecs/ecs_manager.c
@@ -61,7 +61,7 @@ void cre_ecs_manager_enable_fps_display_entity(bool enabled) {
         component_manager_set_component(currentFpsEntity, ComponentDataIndex_SCRIPT, scriptComponent);
         // Update systems
         cre_ec_system_update_entity_signature_with_systems(currentFpsEntity);
-        cre_scene_manager_queue_entity_for_creation(fpsDisplayNode);
+        cre_scene_manager_queue_node_for_creation(fpsDisplayNode);
     } else if (isEnabled && !enabled) {
         SE_ASSERT_FMT(currentFpsEntity != NULL_ENTITY, "Current fps entity is a null entity!?");
         SE_ASSERT_FMT(fpsDisplayNode != NULL, "FPS Display Node is NULL!?");

--- a/engine/src/core/ecs/system/collision_ec_system.c
+++ b/engine/src/core/ecs/system/collision_ec_system.c
@@ -111,8 +111,8 @@ void collision_system_render() {
 }
 
 void collision_system_on_node_entered_scene(Entity entity) {
-    Transform2DComponent* transformComp = (Transform2DComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_TRANSFORM_2D);
-    Collider2DComponent* colliderComp = (Collider2DComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_COLLIDER_2D);
+    Transform2DComponent* transformComp = (Transform2DComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_TRANSFORM_2D);
+    Collider2DComponent* colliderComp = (Collider2DComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_COLLIDER_2D);
     if (transformComp != NULL && colliderComp != NULL) {
         SERect2 collisionRect = cre_get_collision_rectangle(entity, transformComp, colliderComp);
         se_spatial_hash_map_insert_or_update(spatialHashMap, entity, &collisionRect);
@@ -126,7 +126,7 @@ void collision_system_on_transform_update(SESubjectNotifyPayload* payload) {
     Transform2DComponent* transformComp = (Transform2DComponent*) updatePayload->component;
     const Entity entity = updatePayload->entity;
 
-    Collider2DComponent* colliderComp = (Collider2DComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_COLLIDER_2D);
+    Collider2DComponent* colliderComp = (Collider2DComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_COLLIDER_2D);
     if (transformComp != NULL && colliderComp != NULL) {
         SERect2 collisionRect = cre_get_collision_rectangle(entity, transformComp, colliderComp);
         se_spatial_hash_map_insert_or_update(spatialHashMap, entity, &collisionRect);

--- a/engine/src/core/ecs/system/ec_system.c
+++ b/engine/src/core/ecs/system/ec_system.c
@@ -164,7 +164,7 @@ void cre_ec_system_entity_end(Entity entity) {
             entitySystemData.on_entity_end_systems[i]->on_entity_end_func(entity);
         }
     }
-    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE);
+    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE);
     if (nodeComponent != NULL) {
         // Note: Node events should not be created during this time
         se_event_notify_observers(&nodeComponent->onSceneTreeExit, &(SESubjectNotifyPayload) {
@@ -175,7 +175,7 @@ void cre_ec_system_entity_end(Entity entity) {
 
 void cre_ec_system_entity_entered_scene(Entity entity) {
     // Notify scene enter observers before calling it on systems
-    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE);
+    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE);
     if (nodeComponent != NULL) {
         se_event_notify_observers(&nodeComponent->onSceneTreeEnter, &(SESubjectNotifyPayload) {
             .data = &entity, .type = 0

--- a/engine/src/core/ecs/system/parallax_ec_system.c
+++ b/engine/src/core/ecs/system/parallax_ec_system.c
@@ -33,8 +33,8 @@ struct EntitySystem* parallax_ec_system_create() {
 }
 
 void parallax_system_on_entity_entered_scene(Entity entity) {
-    Transform2DComponent* transformComp = (Transform2DComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_TRANSFORM_2D);
-    ParallaxComponent* parallaxComp = (ParallaxComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_PARALLAX);
+    Transform2DComponent* transformComp = (Transform2DComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_TRANSFORM_2D);
+    ParallaxComponent* parallaxComp = (ParallaxComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_PARALLAX);
     SE_ASSERT(transformComp != NULL);
     SE_ASSERT(parallaxComp != NULL);
     parallaxComp->cachedScrollSpeed = parallaxComp->scrollSpeed;
@@ -46,7 +46,7 @@ void parallax_system_on_entity_entered_scene(Entity entity) {
 
 void parallax_system_on_entity_unregistered(Entity entity) {
     // Remove observer
-    Transform2DComponent* transformComp = (Transform2DComponent*) component_manager_get_component_unsafe(entity, ComponentDataIndex_TRANSFORM_2D);
+    Transform2DComponent* transformComp = (Transform2DComponent*) component_manager_get_component_unchecked(entity, ComponentDataIndex_TRANSFORM_2D);
     SE_ASSERT(transformComp != NULL);
     se_event_unregister_observer(&transformComp->onTransformChanged, &parallaxOnEntityTransformChangeObserver);
 }

--- a/engine/src/core/node_event.c
+++ b/engine/src/core/node_event.c
@@ -184,7 +184,7 @@ bool does_entity_have_observer_event_already(Entity observerEntity, NodeEvent* e
 
 void register_entity_to_on_scene_exit_callback(Entity entity) {
     NodeComponent* nodeComp = NULL;
-    if (!eventDatabase.hasEntityRegisteredOnSceneExitCallback[entity] && (nodeComp = component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE))) {
+    if (!eventDatabase.hasEntityRegisteredOnSceneExitCallback[entity] && (nodeComp = component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE))) {
         se_event_register_observer(&nodeComp->onSceneTreeExit, &nodeEntityOnExitSceneObserver);
         eventDatabase.hasEntityRegisteredOnSceneExitCallback[entity] = true;
     }
@@ -192,7 +192,7 @@ void register_entity_to_on_scene_exit_callback(Entity entity) {
 
 void unregister_entity_to_on_scene_exit_callback(Entity entity) {
     NodeComponent* nodeComp = NULL;
-    if (eventDatabase.hasEntityRegisteredOnSceneExitCallback[entity] && (nodeComp = component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE))) {
+    if (eventDatabase.hasEntityRegisteredOnSceneExitCallback[entity] && (nodeComp = component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE))) {
         se_event_unregister_observer(&nodeComp->onSceneTreeExit, &nodeEntityOnExitSceneObserver);
         eventDatabase.hasEntityRegisteredOnSceneExitCallback[entity] = false;
     }

--- a/engine/src/core/scene/scene_manager.c
+++ b/engine/src/core/scene/scene_manager.c
@@ -448,18 +448,17 @@ SceneTreeNode* cre_scene_manager_setup_json_scene_node(JsonSceneNode* jsonSceneN
         component_manager_set_component(node->entity, ComponentDataIndex_PARALLAX, parallaxComponent);
     }
 
-    cre_ec_system_update_entity_signature_with_systems(node->entity);
+    if (!isStagedNodes) {
+        cre_ec_system_update_entity_signature_with_systems(node->entity);
+        cre_scene_manager_queue_node_for_creation(node);
+    } else if (isRoot) {
+        // Staged nodes only need to add root as the children are added within a recursive function
+        cre_scene_manager_stage_child_node_to_be_added_later(node);
+    }
 
     // Children
     for (size_t i = 0; i < jsonSceneNode->childrenCount; i++) {
         cre_scene_manager_setup_json_scene_node(jsonSceneNode->children[i], node, isStagedNodes);
-    }
-
-    if (!isStagedNodes) {
-        cre_scene_manager_queue_node_for_creation(node);
-    } else if (isRoot) {
-        // Staged nodes only need to add root as the children are added within a recursive function
-        cre_scene_manager_add_staged_node_children_to_scene(node);
     }
 
     return node;

--- a/engine/src/core/scene/scene_manager.c
+++ b/engine/src/core/scene/scene_manager.c
@@ -351,18 +351,19 @@ void cre_scene_manager_execute_on_root_and_child_nodes(ExecuteOnAllTreeNodesFunc
 }
 
 // Scene node setup
-void cre_scene_manager_setup_json_scene_node(JsonSceneNode* jsonSceneNode, SceneTreeNode* parent, bool isStagedNodes);
+// Setup nodes and components from passed in json scene node.  Will return the root tree node
+SceneTreeNode* cre_scene_manager_setup_json_scene_node(JsonSceneNode* jsonSceneNode, SceneTreeNode* parent, bool isStagedNodes);
 
 void cre_scene_manager_setup_scene_nodes_from_json(JsonSceneNode* jsonSceneNode) {
     cre_scene_manager_setup_json_scene_node(jsonSceneNode, NULL, false);
 }
 
-void cre_scene_manager_stage_scene_nodes_from_json(JsonSceneNode* jsonSceneNode) {
-    cre_scene_manager_setup_json_scene_node(jsonSceneNode, NULL, true);
+SceneTreeNode* cre_scene_manager_stage_scene_nodes_from_json(JsonSceneNode* jsonSceneNode) {
+    return cre_scene_manager_setup_json_scene_node(jsonSceneNode, NULL, true);
 }
 
 // Recursive
-void cre_scene_manager_setup_json_scene_node(JsonSceneNode* jsonSceneNode, SceneTreeNode* parent, bool isStagedNodes) {
+SceneTreeNode* cre_scene_manager_setup_json_scene_node(JsonSceneNode* jsonSceneNode, SceneTreeNode* parent, bool isStagedNodes) {
     SceneTreeNode* node = cre_scene_tree_create_tree_node(cre_ec_system_create_entity_uid(), parent);
 
     const bool isRoot = parent == NULL;
@@ -460,4 +461,6 @@ void cre_scene_manager_setup_json_scene_node(JsonSceneNode* jsonSceneNode, Scene
         // Staged nodes only need to add root as the children are added within a recursive function
         cre_scene_manager_add_staged_node_children_to_scene(node);
     }
+
+    return node;
 }

--- a/engine/src/core/scene/scene_manager.c
+++ b/engine/src/core/scene/scene_manager.c
@@ -146,13 +146,13 @@ void cre_scene_manager_process_queued_deletion_entities() {
         // Remove entity from systems
         cre_ec_system_remove_entity_from_all_systems(entityToDelete);
         // Remove shader instance if applicable
-        SpriteComponent* spriteComponent = component_manager_get_component_unsafe(entityToDelete, ComponentDataIndex_SPRITE);
+        SpriteComponent* spriteComponent = component_manager_get_component_unchecked(entityToDelete, ComponentDataIndex_SPRITE);
         if (spriteComponent != NULL && spriteComponent->shaderInstanceId != SE_SHADER_INSTANCE_INVALID_ID) {
             SEShaderInstance* shaderInstance = se_shader_cache_get_instance(spriteComponent->shaderInstanceId);
             se_shader_cache_remove_instance(spriteComponent->shaderInstanceId);
             SE_MEM_FREE(shaderInstance);
         }
-        AnimatedSpriteComponent* animatedSpriteComponent = component_manager_get_component_unsafe(entityToDelete, ComponentDataIndex_ANIMATED_SPRITE);
+        AnimatedSpriteComponent* animatedSpriteComponent = component_manager_get_component_unchecked(entityToDelete, ComponentDataIndex_ANIMATED_SPRITE);
         if (animatedSpriteComponent != NULL && animatedSpriteComponent->shaderInstanceId != SE_SHADER_INSTANCE_INVALID_ID) {
             SEShaderInstance* shaderInstance = se_shader_cache_get_instance(animatedSpriteComponent->shaderInstanceId);
             se_shader_cache_remove_instance(animatedSpriteComponent->shaderInstanceId);
@@ -234,7 +234,7 @@ SETransformModel2D* cre_scene_manager_get_scene_node_global_transform(Entity ent
 }
 
 float cre_scene_manager_get_node_full_time_dilation(Entity entity) {
-    NodeComponent* nodeComp = component_manager_get_component_unsafe(entity, ComponentDataIndex_NODE);
+    NodeComponent* nodeComp = component_manager_get_component_unchecked(entity, ComponentDataIndex_NODE);
     // The only thing in the scene without nodes current are native script entities
     if (nodeComp == NULL) {
         return cre_world_get_time_dilation();
@@ -247,7 +247,7 @@ float cre_scene_manager_get_node_full_time_dilation(Entity entity) {
     nodeComp->timeDilation.cachedFullValue = cre_world_get_time_dilation();
     const EntityArray entityArray = cre_scene_manager_get_self_and_parent_nodes(entity);
     for (size_t i = 0; (int) i < entityArray.entityCount; i++) {
-        NodeComponent* entityNodeComp = component_manager_get_component_unsafe(entityArray.entities[i], ComponentDataIndex_NODE);
+        NodeComponent* entityNodeComp = component_manager_get_component_unchecked(entityArray.entities[i], ComponentDataIndex_NODE);
         SE_ASSERT_FMT(entityNodeComp != NULL, "node comp is NULL!");
         nodeComp->timeDilation.cachedFullValue *= entityNodeComp->timeDilation.value;
     }
@@ -335,7 +335,7 @@ void cre_scene_manager_notify_all_on_transform_events(Entity entity, Transform2D
         SceneTreeNode* sceneTreeNode = cre_scene_manager_get_entity_tree_node(entity);
         for (size_t i = 0; i < sceneTreeNode->childCount; i++) {
             const Entity childEntity = sceneTreeNode->children[i]->entity;
-            Transform2DComponent* childTransformComp = (Transform2DComponent*) component_manager_get_component_unsafe(childEntity, ComponentDataIndex_TRANSFORM_2D);
+            Transform2DComponent* childTransformComp = (Transform2DComponent*) component_manager_get_component_unchecked(childEntity, ComponentDataIndex_TRANSFORM_2D);
             if (childTransformComp != NULL) {
                 cre_scene_manager_notify_all_on_transform_events(childEntity, childTransformComp);
             }

--- a/engine/src/core/scene/scene_manager.h
+++ b/engine/src/core/scene/scene_manager.h
@@ -8,10 +8,11 @@ extern "C" {
 #include "../ecs/component/transform2d_component.h"
 #include "../seika/src/math/se_math.h"
 
-// --- Scene Tree --- //
+// Scene Tree
+// Creates a new tree node.  If NULL is passed in for parent, it's expected that it's the root of a scene tree.
 SceneTreeNode* cre_scene_tree_create_tree_node(Entity entity, SceneTreeNode* parent);
 
-// --- Scene Manager --- //
+// Scene Manager
 typedef void (*OnNodeEnteredSceneFunc) (Entity);
 
 typedef struct SceneNodeCallbackSubscriber {
@@ -26,7 +27,10 @@ typedef struct EntityArray {
 
 void cre_scene_manager_initialize();
 void cre_scene_manager_finalize();
-void cre_scene_manager_queue_entity_for_creation(SceneTreeNode* treeNode);
+// Will add entity to the scene upon the beginning of the next frame
+void cre_scene_manager_queue_node_for_creation(SceneTreeNode* treeNode);
+// Will stage a node to be added as a child at a later time (e.g. creating a new node instance)
+void cre_scene_manager_stage_child_node_to_be_added_later(SceneTreeNode* treeNode);
 void cre_scene_manager_process_queued_creation_entities();
 void cre_scene_manager_queue_entity_for_deletion(Entity entity);
 void cre_queue_destroy_tree_node_entity_all(SceneTreeNode* treeNode);

--- a/engine/src/core/scene/scene_manager.h
+++ b/engine/src/core/scene/scene_manager.h
@@ -42,6 +42,7 @@ float cre_scene_manager_get_node_full_time_dilation(Entity entity);
 Entity cre_scene_manager_get_entity_child_by_name(Entity parent, const char* childName);
 SceneTreeNode* cre_scene_manager_get_entity_tree_node(Entity entity);
 bool cre_scene_manager_has_entity_tree_node(Entity entity);
+void cre_scene_manager_add_node_as_child(Entity childEntity, Entity parentEntity);
 EntityArray cre_scene_manager_get_self_and_parent_nodes(Entity entity);
 // Helper function to call notify on entity and children node 'on transform changed' events.  Uses recursion.
 void cre_scene_manager_notify_all_on_transform_events(Entity entity, Transform2DComponent* transformComp);

--- a/engine/src/core/scene/scene_manager.h
+++ b/engine/src/core/scene/scene_manager.h
@@ -4,9 +4,11 @@
 extern "C" {
 #endif
 
+#include "../seika/src/math/se_math.h"
+
 #include "scene_tree.h"
 #include "../ecs/component/transform2d_component.h"
-#include "../seika/src/math/se_math.h"
+#include "../json/json_file_loader.h"
 
 // Scene Tree
 // Creates a new tree node.  If NULL is passed in for parent, it's expected that it's the root of a scene tree.
@@ -31,6 +33,7 @@ void cre_scene_manager_finalize();
 void cre_scene_manager_queue_node_for_creation(SceneTreeNode* treeNode);
 // Will stage a node to be added as a child at a later time (e.g. creating a new node instance)
 void cre_scene_manager_stage_child_node_to_be_added_later(SceneTreeNode* treeNode);
+void cre_scene_manager_stage_scene_nodes_from_json(JsonSceneNode* jsonSceneNode);
 void cre_scene_manager_process_queued_creation_entities();
 void cre_scene_manager_queue_entity_for_deletion(Entity entity);
 void cre_queue_destroy_tree_node_entity_all(SceneTreeNode* treeNode);

--- a/engine/src/core/scene/scene_manager.h
+++ b/engine/src/core/scene/scene_manager.h
@@ -33,7 +33,7 @@ void cre_scene_manager_finalize();
 void cre_scene_manager_queue_node_for_creation(SceneTreeNode* treeNode);
 // Will stage a node to be added as a child at a later time (e.g. creating a new node instance)
 void cre_scene_manager_stage_child_node_to_be_added_later(SceneTreeNode* treeNode);
-void cre_scene_manager_stage_scene_nodes_from_json(JsonSceneNode* jsonSceneNode);
+SceneTreeNode* cre_scene_manager_stage_scene_nodes_from_json(JsonSceneNode* jsonSceneNode);
 void cre_scene_manager_process_queued_creation_entities();
 void cre_scene_manager_queue_entity_for_deletion(Entity entity);
 void cre_queue_destroy_tree_node_entity_all(SceneTreeNode* treeNode);

--- a/engine/src/core/scene/scene_template_cache.c
+++ b/engine/src/core/scene/scene_template_cache.c
@@ -1,0 +1,63 @@
+#include "scene_template_cache.h"
+
+#include <string.h>
+
+#include "../seika/src/asset/asset_file_loader.h"
+#include "../seika/src/data_structures/se_hash_map_string.h"
+#include "../seika/src/utils/se_assert.h"
+#include "../seika/src/utils/se_string_util.h"
+
+#include "../json/json_file_loader.h"
+
+typedef struct SECachedSceneTemplate {
+    char* path;
+    JsonSceneNode* rootNode;
+} SECachedSceneTemplate;
+
+static SECachedSceneTemplate cachedSceneTemplates[CRE_SCENE_CACHE_MAX_ITEMS];
+CreSceneCacheId numberOfCachedSceneTemplates = 0;
+
+CreSceneCacheId scene_template_get_cache_id(const char* scenePath);
+
+void cre_scene_template_cache_initialize() {}
+
+void cre_scene_template_cache_finalize() {
+    for (CreSceneCacheId cacheId = 0; cacheId < numberOfCachedSceneTemplates; cacheId++) {
+        if (cachedSceneTemplates[cacheId].path) {
+            SE_MEM_FREE(cachedSceneTemplates[cacheId].path);
+        }
+        if (cachedSceneTemplates[cacheId].rootNode) {
+            cre_json_delete_json_scene_node(cachedSceneTemplates[cacheId].rootNode);
+        }
+    }
+    numberOfCachedSceneTemplates = 0;
+}
+
+CreSceneCacheId cre_scene_template_cache_load_scene(const char* scenePath) {
+    CreSceneCacheId cacheId = CRE_SCENE_CACHE_INVALID_ID;
+    char* sceneText = sf_asset_file_loader_read_file_contents_as_string(scenePath, NULL);
+    if (sceneText) {
+        // Check if we already have the scene cached
+        cacheId = scene_template_get_cache_id(scenePath);
+        if (cacheId == CRE_SCENE_CACHE_INVALID_ID) {
+            // We don't have it cached, so create a new one
+            cacheId = numberOfCachedSceneTemplates++;
+            cachedSceneTemplates[cacheId].path = se_strdup(scenePath);
+            cachedSceneTemplates[cacheId].rootNode = cre_json_load_scene_file(scenePath);
+        }
+    }
+    return cacheId;
+}
+
+JsonSceneNode* cre_scene_template_cache_get_scene(CreSceneCacheId cacheId) {
+    return cachedSceneTemplates[cacheId].rootNode;
+}
+
+CreSceneCacheId scene_template_get_cache_id(const char* scenePath) {
+    for (CreSceneCacheId cacheId = 0; cacheId < numberOfCachedSceneTemplates; cacheId++) {
+        if (strcmp(cachedSceneTemplates[cacheId].path, scenePath) == 0) {
+            return cacheId;
+        }
+    }
+    return CRE_SCENE_CACHE_INVALID_ID;
+}

--- a/engine/src/core/scene/scene_template_cache.h
+++ b/engine/src/core/scene/scene_template_cache.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define CRE_SCENE_CACHE_MAX_ITEMS 100
+#define CRE_SCENE_CACHE_INVALID_ID (-1)
+
+typedef int CreSceneCacheId;
+
+void cre_scene_template_cache_initialize();
+void cre_scene_template_cache_finalize();
+CreSceneCacheId cre_scene_template_cache_load_scene(const char* scenePath);
+struct JsonSceneNode* cre_scene_template_cache_get_scene(CreSceneCacheId cacheId);

--- a/engine/src/core/scene/scene_utils.c
+++ b/engine/src/core/scene/scene_utils.c
@@ -12,7 +12,7 @@ on_get_local_transform onGetLocalTransformFunc = &default_get_local_transform;
 
 // Default engine callbacks
 SETransform2D default_get_local_transform(Entity entity, int* zIndex, bool* success) {
-    Transform2DComponent* transform2DComponent = component_manager_get_component_unsafe(entity, ComponentDataIndex_TRANSFORM_2D);
+    Transform2DComponent* transform2DComponent = component_manager_get_component_unchecked(entity, ComponentDataIndex_TRANSFORM_2D);
     if (transform2DComponent == NULL) {
         *success = false;
         return (SETransform2D) {

--- a/engine/src/core/scene/scene_utils.h
+++ b/engine/src/core/scene/scene_utils.h
@@ -19,6 +19,7 @@ void cre_scene_utils_override_on_get_self_and_parent_entities_func(on_get_self_a
 void cre_scene_utils_override_on_get_local_transform_func(on_get_local_transform func);
 EntityArray cre_scene_utils_get_self_and_parent_entities(Entity entity);
 void cre_scene_utils_reset_callback_func_overrides();
+void cre_scene_utils_load_scene_into_cache(const char* scenePath);
 
 #ifdef __cplusplus
 }

--- a/engine/src/core/scene/scene_utils.h
+++ b/engine/src/core/scene/scene_utils.h
@@ -19,7 +19,6 @@ void cre_scene_utils_override_on_get_self_and_parent_entities_func(on_get_self_a
 void cre_scene_utils_override_on_get_local_transform_func(on_get_local_transform func);
 EntityArray cre_scene_utils_get_self_and_parent_entities(Entity entity);
 void cre_scene_utils_reset_callback_func_overrides();
-void cre_scene_utils_load_scene_into_cache(const char* scenePath);
 
 #ifdef __cplusplus
 }

--- a/engine/src/core/scripting/native/native_script_context.c
+++ b/engine/src/core/scripting/native/native_script_context.c
@@ -63,17 +63,10 @@ void native_on_create_instance(Entity entity, const char* classPath, const char*
     SE_ASSERT(scriptClassRef->create_new_instance_func != NULL);
     CRENativeScriptClass* newScriptClass = scriptClassRef->create_new_instance_func(entity);
     se_hash_map_add(entityToClassName, &entity, &newScriptClass);
-    if (newScriptClass->update_func != NULL) {
-        native_script_context->updateEntities[native_script_context->updateEntityCount++] = entity;
-    }
-    if (newScriptClass->physics_update_func != NULL) {
-        native_script_context->physicsUpdateEntities[native_script_context->physicsUpdateEntityCount++] = entity;
-    }
 }
 
 void native_on_delete_instance(Entity entity) {
-    CRENativeScriptClass* scriptClassRef = (CRENativeScriptClass*) *(CRENativeScriptClass**) se_hash_map_get(
-            entityToClassName, &entity);
+    CRENativeScriptClass* scriptClassRef = (CRENativeScriptClass*) *(CRENativeScriptClass**) se_hash_map_get(entityToClassName, &entity);
 
     if (scriptClassRef->update_func != NULL) {
         se_array_utils_remove_item_uint32(
@@ -98,9 +91,15 @@ void native_on_delete_instance(Entity entity) {
 
 void native_on_start(Entity entity) {
     SE_ASSERT(se_hash_map_has(entityToClassName, &entity));
-    CRENativeScriptClass* scriptClassRef = (CRENativeScriptClass*) *(CRENativeScriptClass**) se_hash_map_get(
-            entityToClassName, &entity);
+    CRENativeScriptClass* scriptClassRef = (CRENativeScriptClass*) *(CRENativeScriptClass**) se_hash_map_get(entityToClassName, &entity);
     scriptClassRef->on_start_func(scriptClassRef);
+    // Check if entity has update functions
+    if (scriptClassRef->update_func != NULL) {
+        native_script_context->updateEntities[native_script_context->updateEntityCount++] = entity;
+    }
+    if (scriptClassRef->physics_update_func != NULL) {
+        native_script_context->physicsUpdateEntities[native_script_context->physicsUpdateEntityCount++] = entity;
+    }
 }
 
 void native_on_update_instance(Entity entity, float deltaTime) {

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -39,6 +39,7 @@
 #include "../../scene/scene_manager.h"
 #include "../../ecs/component/parallax_component.h"
 #include "../../math/curve_float_manager.h"
+#include "../../scene/scene_template_cache.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996) // for strcpy
@@ -860,15 +861,7 @@ PyObject* cre_py_api_node_add_child(PyObject* self, PyObject* args, PyObject* kw
     Entity parentEntity;
     Entity entity;
     if (PyArg_ParseTupleAndKeywords(args, kwargs, "ii", crePyApiNodeAddChildKWList, &parentEntity, &entity)) {
-        SceneTreeNode* parentNode = cre_scene_manager_get_entity_tree_node(parentEntity);
-        SceneTreeNode* node = cre_scene_tree_create_tree_node(entity, parentNode);
-        if (parentNode != NULL) {
-            SE_ASSERT(parentNode->childCount + 1 < SCENE_TREE_NODE_MAX_CHILDREN);
-            parentNode->children[parentNode->childCount++] = node;
-        }
-
-        cre_ec_system_update_entity_signature_with_systems(entity);
-        cre_scene_manager_queue_entity_for_creation(node);
+        cre_scene_manager_add_node_as_child(entity, parentEntity);
         Py_RETURN_NONE;
     }
     return NULL;
@@ -1858,10 +1851,11 @@ PyObject* cre_py_api_game_config_load(PyObject* self, PyObject* args, PyObject* 
 PyObject* cre_py_api_scene_util_load_scene(PyObject* self, PyObject* args, PyObject* kwargs) {
     char* scenePath;
     if (PyArg_ParseTupleAndKeywords(args, kwargs, "s", crePyApiGenericPathKWList, &scenePath)) {
-        int packedId = -1;
+        CreSceneCacheId packedId = CRE_SCENE_CACHE_INVALID_ID;
         char* sceneText = sf_asset_file_loader_read_file_contents_as_string(scenePath, NULL);
         if (sceneText) {
             // TODO: Create or get packed scene id
+            packedId = cre_scene_template_cache_load_scene(scenePath);
         }
         return Py_BuildValue("i", packedId);
     }

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -799,10 +799,9 @@ PyObject* cre_py_api_node_new(PyObject* self, PyObject* args, PyObject* kwargs) 
         ScriptComponent* scriptComponent = script_component_create(classPath, className);
         scriptComponent->contextType = ScriptContextType_PYTHON;
         component_manager_set_component(newNode->entity, ComponentDataIndex_SCRIPT, scriptComponent);
-        // Call create instance on script context
-        // TODO: Not a big fan of updating the scripting system signature this way, but I guess it will suffice for now...
-        cre_ec_system_update_entity_signature_with_systems(newNode->entity);
-        PyObject* entityInstance = cre_py_get_script_instance(newNode->entity);
+        // Call create instance on script context.
+        // Note: python script context checks to make sure the instance for an entity is only created once
+        PyObject* entityInstance = cre_py_create_script_instance(newNode->entity, classPath, className);
         SE_ASSERT_FMT(entityInstance != NULL, "Entity instance '%d' is NULL!", newNode->entity);
 
         NodeComponent* nodeComponent = node_component_create();
@@ -1853,7 +1852,13 @@ PyObject* cre_py_api_game_config_load(PyObject* self, PyObject* args, PyObject* 
 PyObject* cre_py_api_packed_scene_create_instance(PyObject* self, PyObject* args, PyObject* kwargs) {
     CreSceneCacheId cacheId;
     if (PyArg_ParseTupleAndKeywords(args, kwargs, "i", crePyApiPackedSceneCreateInstanceKWList, &cacheId)) {
-        struct JsonSceneNode* sceneNode = cre_scene_template_cache_get_scene(cacheId);
+        JsonSceneNode* sceneNode = cre_scene_template_cache_get_scene(cacheId);
+        cre_scene_manager_stage_scene_nodes_from_json(sceneNode);
+        // TODO: Finish by getting entity, classPath, and className
+//        PyObject* entityInstance = cre_py_create_script_instance();
+//
+//        Py_IncRef(entityInstance);
+//        return Py_BuildValue("O", entityInstance);
     }
     return NULL;
 }

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -710,7 +710,7 @@ PyObject* cre_py_api_camera2D_unfollow_node(PyObject* self, PyObject* args, PyOb
 
 // World
 void py_mark_scene_nodes_time_dilation_flag_dirty(SceneTreeNode* node) {
-    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unsafe(node->entity, ComponentDataIndex_NODE);
+    NodeComponent* nodeComponent = (NodeComponent*) component_manager_get_component_unchecked(node->entity, ComponentDataIndex_NODE);
     SE_ASSERT(nodeComponent != NULL);
     nodeComponent->timeDilation.cacheInvalid = true;
 }
@@ -1854,11 +1854,14 @@ PyObject* cre_py_api_packed_scene_create_instance(PyObject* self, PyObject* args
     if (PyArg_ParseTupleAndKeywords(args, kwargs, "i", crePyApiPackedSceneCreateInstanceKWList, &cacheId)) {
         JsonSceneNode* sceneNode = cre_scene_template_cache_get_scene(cacheId);
         SceneTreeNode* rootNode = cre_scene_manager_stage_scene_nodes_from_json(sceneNode);
-        // TODO: Finish by getting entity, classPath, and className
-//        PyObject* entityInstance = cre_py_create_script_instance();
-//
-//        Py_IncRef(entityInstance);
-//        return Py_BuildValue("O", entityInstance);
+        ScriptComponent* scriptComponent = (ScriptComponent*) component_manager_get_component_unchecked(rootNode->entity, ComponentDataIndex_SCRIPT);
+        if (!scriptComponent) {
+            // TODO: Create new script component if it doesn't exist
+        }
+        PyObject* entityInstance = cre_py_create_script_instance(rootNode->entity, scriptComponent->classPath, scriptComponent->className);
+
+        Py_IncRef(entityInstance);
+        return Py_BuildValue("O", entityInstance);
     }
     return NULL;
 }

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -1856,7 +1856,9 @@ PyObject* cre_py_api_packed_scene_create_instance(PyObject* self, PyObject* args
         SceneTreeNode* rootNode = cre_scene_manager_stage_scene_nodes_from_json(sceneNode);
         ScriptComponent* scriptComponent = (ScriptComponent*) component_manager_get_component_unchecked(rootNode->entity, ComponentDataIndex_SCRIPT);
         if (!scriptComponent) {
-            // TODO: Create new script component if it doesn't exist
+            // Create new script component if it doesn't exist
+            scriptComponent = script_component_create("crescent_api", node_get_base_type_string(sceneNode->type));
+            component_manager_set_component(rootNode->entity, ComponentDataIndex_SCRIPT, scriptComponent);
         }
         PyObject* entityInstance = cre_py_create_script_instance(rootNode->entity, scriptComponent->classPath, scriptComponent->className);
 

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -1858,6 +1858,7 @@ PyObject* cre_py_api_packed_scene_create_instance(PyObject* self, PyObject* args
         if (!scriptComponent) {
             // Create new script component if it doesn't exist
             scriptComponent = script_component_create("crescent_api", node_get_base_type_string(sceneNode->type));
+            scriptComponent->contextType = ScriptContextType_PYTHON;
             component_manager_set_component(rootNode->entity, ComponentDataIndex_SCRIPT, scriptComponent);
         }
         PyObject* entityInstance = cre_py_create_script_instance(rootNode->entity, scriptComponent->classPath, scriptComponent->className);

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -1853,7 +1853,7 @@ PyObject* cre_py_api_packed_scene_create_instance(PyObject* self, PyObject* args
     CreSceneCacheId cacheId;
     if (PyArg_ParseTupleAndKeywords(args, kwargs, "i", crePyApiPackedSceneCreateInstanceKWList, &cacheId)) {
         JsonSceneNode* sceneNode = cre_scene_template_cache_get_scene(cacheId);
-        cre_scene_manager_stage_scene_nodes_from_json(sceneNode);
+        SceneTreeNode* rootNode = cre_scene_manager_stage_scene_nodes_from_json(sceneNode);
         // TODO: Finish by getting entity, classPath, and className
 //        PyObject* entityInstance = cre_py_create_script_instance();
 //

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -1853,3 +1853,17 @@ PyObject* cre_py_api_game_config_load(PyObject* self, PyObject* args, PyObject* 
     }
     return Py_BuildValue("s", "{}");
 }
+
+// Scene Util
+PyObject* cre_py_api_scene_util_load_scene(PyObject* self, PyObject* args, PyObject* kwargs) {
+    char* scenePath;
+    if (PyArg_ParseTupleAndKeywords(args, kwargs, "s", crePyApiGenericPathKWList, &scenePath)) {
+        int packedId = -1;
+        char* sceneText = sf_asset_file_loader_read_file_contents_as_string(scenePath, NULL);
+        if (sceneText) {
+            // TODO: Create or get packed scene id
+        }
+        return Py_BuildValue("i", packedId);
+    }
+    return NULL;
+}

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -1876,7 +1876,6 @@ PyObject* cre_py_api_scene_util_load_scene(PyObject* self, PyObject* args, PyObj
         CreSceneCacheId cacheId = CRE_SCENE_CACHE_INVALID_ID;
         char* sceneText = sf_asset_file_loader_read_file_contents_as_string(scenePath, NULL);
         if (sceneText) {
-            // TODO: Create or get packed scene id
             cacheId = cre_scene_template_cache_load_scene(scenePath);
         }
         return Py_BuildValue("i", cacheId);

--- a/engine/src/core/scripting/python/cre_py_api_module.h
+++ b/engine/src/core/scripting/python/cre_py_api_module.h
@@ -191,6 +191,9 @@ PyObject* cre_py_api_collision_handler_process_mouse_collisions(PyObject* self, 
 PyObject* cre_py_api_game_config_save(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_game_config_load(PyObject* self, PyObject* args, PyObject* kwargs);
 
+// Scene Utils
+PyObject* cre_py_api_scene_util_load_scene(PyObject* self, PyObject* args, PyObject* kwargs);
+
 
 // --- Module Methods Definitions --- //
 static struct PyMethodDef crePyApiMethods[] = {
@@ -778,7 +781,11 @@ static struct PyMethodDef crePyApiMethods[] = {
         "game_config_load", (PyCFunction) cre_py_api_game_config_load,
         METH_VARARGS | METH_KEYWORDS, "Loads a game config."
     },
-    // COLLISION HANDLER
+    // SCENE UTIL
+    {
+        "scene_util_load_scene", (PyCFunction) cre_py_api_scene_util_load_scene,
+        METH_VARARGS | METH_KEYWORDS, "Loads a packed scene by path."
+    },
     { NULL, NULL, 0,NULL },
 };
 

--- a/engine/src/core/scripting/python/cre_py_api_module.h
+++ b/engine/src/core/scripting/python/cre_py_api_module.h
@@ -191,6 +191,9 @@ PyObject* cre_py_api_collision_handler_process_mouse_collisions(PyObject* self, 
 PyObject* cre_py_api_game_config_save(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_game_config_load(PyObject* self, PyObject* args, PyObject* kwargs);
 
+// Packed Scene
+PyObject* cre_py_api_packed_scene_create_instance(PyObject* self, PyObject* args, PyObject* kwargs);
+
 // Scene Utils
 PyObject* cre_py_api_scene_util_load_scene(PyObject* self, PyObject* args, PyObject* kwargs);
 
@@ -781,6 +784,11 @@ static struct PyMethodDef crePyApiMethods[] = {
         "game_config_load", (PyCFunction) cre_py_api_game_config_load,
         METH_VARARGS | METH_KEYWORDS, "Loads a game config."
     },
+    // PACKED SCENE
+    {
+        "packed_scene_create_instance", (PyCFunction) cre_py_api_packed_scene_create_instance,
+        METH_VARARGS | METH_KEYWORDS, "Creates a node instance from a packed scene."
+    },
     // SCENE UTIL
     {
         "scene_util_load_scene", (PyCFunction) cre_py_api_scene_util_load_scene,
@@ -870,6 +878,8 @@ static char* crePyApiClientStartKWList[] = {"host", "port", NULL};
 static char* crePyApiWorldSetTimeDilationKWList[] = {"time_dilation", NULL};
 
 static char* crePyApiCollisionHandlerProcessMouseCollisionsKWList[] = {"pos_offset_x", "pos_offset_y", "collision_size_w", "collision_size_h", NULL};
+
+static char* crePyApiPackedSceneCreateInstanceKWList[] = {"scene_cache_id", NULL};
 
 static char* crePyApiGameConfigSaveKWList[] = {"path", "data_json", "encryption_key", NULL};
 static char* crePyApiGameConfigLoadKWList[] = {"path", "encryption_key", NULL};

--- a/engine/src/core/scripting/python/crescent_api_source.h
+++ b/engine/src/core/scripting/python/crescent_api_source.h
@@ -1664,16 +1664,21 @@
 "\n"\
 "\n"\
 "class PackedScene:\n"\
-"    def __init__(self, packed_id: int, path: str):\n"\
-"        self.packed_id = packed_id\n"\
+"    def __init__(self, scene_cache_id: int, path: str):\n"\
+"        self.scene_cache_id = scene_cache_id\n"\
 "        self.path = path\n"\
+"\n"\
+"    def create_instance(self):\n"\
+"        return crescent_api_internal.packed_scene_create_instance(\n"\
+"            scene_cache_id=self.scene_cache_id\n"\
+"        )\n"\
 "\n"\
 "\n"\
 "class SceneUtil:\n"\
 "    @staticmethod\n"\
 "    def load_scene(path: str) -> Optional[PackedScene]:\n"\
-"        packed_id = crescent_api_internal.scene_util_load_scene(path=path)\n"\
-"        if packed_id < 0:\n"\
+"        scene_cache_id = crescent_api_internal.scene_util_load_scene(path=path)\n"\
+"        if scene_cache_id < 0:\n"\
 "            return None\n"\
-"        return PackedScene(packed_id=packed_id, path=path)\n"\
+"        return PackedScene(scene_cache_id=scene_cache_id, path=path)\n"\
 "\n"

--- a/engine/src/core/scripting/python/crescent_api_source.h
+++ b/engine/src/core/scripting/python/crescent_api_source.h
@@ -1668,7 +1668,7 @@
 "        self.scene_cache_id = scene_cache_id\n"\
 "        self.path = path\n"\
 "\n"\
-"    def create_instance(self):\n"\
+"    def create_instance(self) -> Node:\n"\
 "        return crescent_api_internal.packed_scene_create_instance(\n"\
 "            scene_cache_id=self.scene_cache_id\n"\
 "        )\n"\

--- a/engine/src/core/scripting/python/crescent_api_source.h
+++ b/engine/src/core/scripting/python/crescent_api_source.h
@@ -1661,4 +1661,19 @@
 "            print(f\"Game Config Load Json Decode Error: {e}\")\n"\
 "            return {}\n"\
 "        return json_dict\n"\
+"\n"\
+"\n"\
+"class PackedScene:\n"\
+"    def __init__(self, packed_id: int, path: str):\n"\
+"        self.packed_id = packed_id\n"\
+"        self.path = path\n"\
+"\n"\
+"\n"\
+"class SceneUtil:\n"\
+"    @staticmethod\n"\
+"    def load_scene(path: str) -> Optional[PackedScene]:\n"\
+"        packed_id = crescent_api_internal.scene_util_load_scene(path=path)\n"\
+"        if packed_id < 0:\n"\
+"            return None\n"\
+"        return PackedScene(packed_id=packed_id, path=path)\n"\
 "\n"

--- a/engine/src/core/scripting/python/py_script_context.c
+++ b/engine/src/core/scripting/python/py_script_context.c
@@ -63,12 +63,6 @@ CREScriptContext* cre_py_get_script_context() {
 
 void py_on_create_instance(Entity entity, const char* classPath, const char* className) {
     PyObject* pScriptInstance = cre_py_cache_create_instance(classPath, className, entity);
-    if (PyObject_HasAttrString(pScriptInstance, "_update")) {
-        python_script_context->updateEntities[python_script_context->updateEntityCount++] = entity;
-    }
-    if (PyObject_HasAttrString(pScriptInstance, "_physics_update")) {
-        python_script_context->physicsUpdateEntities[python_script_context->physicsUpdateEntityCount++] = entity;
-    }
     se_hash_map_add(pythonInstanceHashMap, &entity, &pScriptInstance);
 }
 
@@ -114,6 +108,12 @@ void py_on_start(Entity entity) {
     node_event_notify_observers(entity, "scene_entered", &(NodeEventNotifyPayload) {
         .data = pScriptInstance
     });
+    if (PyObject_HasAttrString(pScriptInstance, "_update")) {
+        python_script_context->updateEntities[python_script_context->updateEntityCount++] = entity;
+    }
+    if (PyObject_HasAttrString(pScriptInstance, "_physics_update")) {
+        python_script_context->physicsUpdateEntities[python_script_context->physicsUpdateEntityCount++] = entity;
+    }
 }
 
 void py_on_pre_update_all() {

--- a/engine/src/core/scripting/python/py_script_context.c
+++ b/engine/src/core/scripting/python/py_script_context.c
@@ -198,7 +198,6 @@ PyObject* cre_py_create_script_instance(Entity entity, const char* classPath, co
     return cre_py_get_script_instance(entity);
 }
 
-
 PyObject* cre_py_get_script_instance(Entity entity) {
     if (se_hash_map_has(pythonInstanceHashMap, &entity)) {
         return (PyObject*) *(PyObject**) se_hash_map_get(pythonInstanceHashMap, &entity);

--- a/engine/src/core/scripting/python/py_script_context.c
+++ b/engine/src/core/scripting/python/py_script_context.c
@@ -62,6 +62,10 @@ CREScriptContext* cre_py_get_script_context() {
 }
 
 void py_on_create_instance(Entity entity, const char* classPath, const char* className) {
+    if (se_hash_map_has(pythonInstanceHashMap, &entity)) {
+        se_logger_warn("Won't create entity '%d' with class_path '%s' and class_name '%s' as they already exist!", entity, classPath, className);
+        return;
+    }
     PyObject* pScriptInstance = cre_py_cache_create_instance(classPath, className, entity);
     se_hash_map_add(pythonInstanceHashMap, &entity, &pScriptInstance);
 }
@@ -187,6 +191,13 @@ void cre_py_on_network_udp_server_client_connected() {
         PyGILState_Release(pyGilStateState);
     }
 }
+
+PyObject* cre_py_create_script_instance(Entity entity, const char* classPath, const char* className) {
+    SE_ASSERT(python_script_context != NULL);
+    python_script_context->on_create_instance(entity, classPath, className);
+    return cre_py_get_script_instance(entity);
+}
+
 
 PyObject* cre_py_get_script_instance(Entity entity) {
     if (se_hash_map_has(pythonInstanceHashMap, &entity)) {

--- a/engine/src/core/scripting/python/py_script_context.h
+++ b/engine/src/core/scripting/python/py_script_context.h
@@ -6,4 +6,5 @@ struct CREScriptContext* cre_py_create_script_context();
 struct CREScriptContext* cre_py_get_script_context();
 
 void cre_py_on_network_udp_server_client_connected();
+struct _object* cre_py_create_script_instance(Entity entity, const char* classPath, const char* className);
 struct _object* cre_py_get_script_instance(Entity entity);


### PR DESCRIPTION
- Can load a packed scene from scene json files and create instanced of them.  Was previously able to add external scene files to other, but can now create instances of them from python-api.
- Fixed bug related to sometimes calling `_update` and `_physics_update` before node was added to scene