### PR TITLE
Can now maintain a game resolution's aspect ratio

### DIFF
--- a/editor/src/core/components/component.h
+++ b/editor/src/core/components/component.h
@@ -216,7 +216,7 @@ struct Collider2DComp : public EditorComponent {
           color(collider2DComponent->color) {}
 
     SESize2D extents = { .w = 0.0f, .h = 0.0f };
-    SEColor color = { .r = 0.0f, .g = 0.0f, .b = 0.8f, .a = 1.0f };
+    SEColor color = { .r = 0.0f, .g = 0.0f, .b = 0.8f, .a = 0.8f };
 };
 
 struct ColorRectComp : public EditorComponent {

--- a/editor/src/core/editor.cpp
+++ b/editor/src/core/editor.cpp
@@ -41,7 +41,7 @@ bool Editor::Initialize() {
     cre_py_initialize(editorContext->GetEngineBinPath().c_str());
 
     // TODO: Figure out window stuff dimensions...
-    se_renderer_initialize(800, 600, 800, 600);
+    se_renderer_initialize(800, 600, 800, 600, false);
 
     // Initialize Asset Manager
     AssetManager::Get()->Initialize();

--- a/editor/src/core/project_properties.cpp
+++ b/editor/src/core/project_properties.cpp
@@ -88,6 +88,7 @@ void ProjectProperties::LoadPropertiesFromConfig(const char* filePath) {
     windowHeight = JsonHelper::Get<int>(propertyJson, "window_height");
     resolutionWidth = JsonHelper::Get<int>(propertyJson, "resolution_width");
     resolutionHeight = JsonHelper::Get<int>(propertyJson, "resolution_height");
+    maintainAspectRatio = JsonHelper::GetDefault<bool>(propertyJson, "maintain_aspect_ratio", false);
     targetFPS = JsonHelper::Get<int>(propertyJson, "target_fps");
     areCollidersVisible = JsonHelper::Get<bool>(propertyJson, "colliders_visible");
     version = JsonHelper::GetDefault<std::string>(propertyJson, "version", "0.0.1");
@@ -155,6 +156,7 @@ nlohmann::ordered_json ProjectProperties::ToJson() const {
     configJson["window_height"] = windowHeight;
     configJson["resolution_width"] = resolutionWidth;
     configJson["resolution_height"] = resolutionHeight;
+    configJson["maintain_aspect_ratio"] = maintainAspectRatio;
     configJson["target_fps"] = targetFPS;
     configJson["initial_node_path"] = initialNodePath;
     configJson["colliders_visible"] = areCollidersVisible;

--- a/editor/src/core/project_properties.h
+++ b/editor/src/core/project_properties.h
@@ -84,6 +84,7 @@ class ProjectProperties : public Singleton<ProjectProperties> {
     int windowHeight;
     int resolutionWidth;
     int resolutionHeight;
+    bool maintainAspectRatio = false;
     int targetFPS;
     bool areCollidersVisible = false;
     std::string version;

--- a/editor/src/core/ui/views/opened_project/menu_bar_ui.cpp
+++ b/editor/src/core/ui/views/opened_project/menu_bar_ui.cpp
@@ -175,6 +175,9 @@ ImGuiHelper::MenuBar OpenedProjectUI::MenuBar::GetMenuBar() {
                                     static ImGuiHelper::DragInt resolutionHeightInt("Resolution Height", projectProperties->resolutionHeight);
                                     ImGuiHelper::BeginDragInt(resolutionHeightInt);
 
+                                    static ImGuiHelper::CheckBox maintainAspectRatioCheckBox("Maintain Aspect Ratio", projectProperties->maintainAspectRatio);
+                                    ImGuiHelper::BeginCheckBox(maintainAspectRatioCheckBox);
+
                                     static ImGuiHelper::DragInt targetFPSInt("Target FPS", projectProperties->targetFPS);
                                     ImGuiHelper::BeginDragInt(targetFPSInt);
 

--- a/editor/src/core/ui/views/opened_project/windows/scene_view_ui.cpp
+++ b/editor/src/core/ui/views/opened_project/windows/scene_view_ui.cpp
@@ -99,7 +99,8 @@ ImGuiHelper::Window OpenedProjectUI::Windows::GetSceneViewWindow() {
                     .color = color,
                     .flipH = flipH,
                     .flipV = flipV,
-                    .globalTransform = &globalTransforms[index]
+                    .globalTransform = &globalTransforms[index],
+                    .zIndex = globalTransforms[index].zIndex
                 };
             };
             static SceneManager* sceneManager = SceneManager::Get();
@@ -127,7 +128,8 @@ ImGuiHelper::Window OpenedProjectUI::Windows::GetSceneViewWindow() {
                                 .text = textLabelComp->text,
                                 .position = globalTransform.position,
                                 .scale = globalTransform.scale.x,
-                                .color = textLabelComp->color
+                                .color = textLabelComp->color,
+                                .zIndex = globalTransform.zIndex
                             };
                             fontRenderTargets.emplace_back(renderTarget);
                         } else {

--- a/engine/src/core/core.c
+++ b/engine/src/core/core.c
@@ -115,6 +115,7 @@ bool cre_initialize(int argv, char** args) {
                                          gameProperties->windowHeight,
                                          gameProperties->resolutionWidth,
                                          gameProperties->resolutionHeight,
+                                         gameProperties->maintainAspectRatio,
                                          controllerMappingFilePath
                                      );
     if (!hasSeikaInitialized) {

--- a/engine/src/core/game_properties.c
+++ b/engine/src/core/game_properties.c
@@ -15,6 +15,7 @@ CREGameProperties* cre_game_props_create() {
     props->windowHeight = 600;
     props->resolutionWidth = props->windowWidth;
     props->resolutionHeight = props->windowHeight;
+    props->maintainAspectRatio = false;
     props->targetFPS = 66;
     props->initialScenePath = NULL;
     props->areCollidersVisible = false;

--- a/engine/src/core/game_properties.h
+++ b/engine/src/core/game_properties.h
@@ -53,6 +53,7 @@ typedef struct CREGameProperties {
     int resolutionHeight;
     int windowWidth;
     int windowHeight;
+    bool maintainAspectRatio;
     int targetFPS;
     char* initialScenePath;
     bool areCollidersVisible;

--- a/engine/src/core/json/json_file_loader.c
+++ b/engine/src/core/json/json_file_loader.c
@@ -104,6 +104,9 @@ CREGameProperties* cre_json_load_config_file(const char* filePath) {
         // Resolution Height
         properties->resolutionHeight = json_get_int(configJson, "resolution_height");
         se_logger_debug("Resolution Height: '%d'", properties->resolutionHeight);
+        // Maintain Aspect Ratio
+        properties->maintainAspectRatio = json_get_bool_default(configJson, "maintain_aspect_ratio", false);
+        se_logger_debug("Maintain Aspect Ratio '%s'", properties->maintainAspectRatio == true ? "true" : "false");
         // Target FPS
         properties->targetFPS = json_get_int(configJson, "target_fps");
         se_logger_debug("Target FPS '%d'", properties->targetFPS);

--- a/engine/src/core/scene/scene_utils.c
+++ b/engine/src/core/scene/scene_utils.c
@@ -12,8 +12,7 @@ on_get_local_transform onGetLocalTransformFunc = &default_get_local_transform;
 
 // Default engine callbacks
 SETransform2D default_get_local_transform(CreEntity entity, int* zIndex, bool* success) {
-    Transform2DComponent* transform2DComponent = cre_component_manager_get_component_unchecked(entity,
-            CreComponentDataIndex_TRANSFORM_2D);
+    Transform2DComponent* transform2DComponent = cre_component_manager_get_component_unchecked(entity, CreComponentDataIndex_TRANSFORM_2D);
     if (transform2DComponent == NULL) {
         *success = false;
         return (SETransform2D) {

--- a/seika/src/math/se_math.h
+++ b/seika/src/math/se_math.h
@@ -28,6 +28,12 @@ typedef struct SESize2D {
     float h;
 } SESize2D;
 
+// --- SESize2Di --- //
+typedef struct SESize2Di {
+    int w;
+    int h;
+} SESize2Di;
+
 // --- SERect2 --- //
 typedef struct SERect2 {
     float x;

--- a/seika/src/math/se_math.h
+++ b/seika/src/math/se_math.h
@@ -22,6 +22,12 @@ typedef struct SEVector2 {
 bool se_math_vec2_equals(const SEVector2* v1, const SEVector2* v2);
 SEVector2 se_math_vec2_lerp(const SEVector2* v1, const SEVector2* v2, float t);
 
+// --- SEVector2i --- //
+typedef struct SEVector2i {
+    int x;
+    int y;
+} SEVector2i;
+
 // --- SESize2D --- //
 typedef struct SESize2D {
     float w;

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -133,7 +133,6 @@ bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inRes
         .shader = screenShader, .paramMap = se_string_hash_map_create_default_capacity()
     };
     se_frame_buffer_set_screen_shader(&defaultScreenShader);
-    verticesDataDirty = true;
     se_frame_buffer_generate_viewport_data(inWindowWidth, inWindowHeight);
 
     hasBeenInitialized = true;
@@ -167,7 +166,6 @@ void se_frame_buffer_resize_texture(int newWidth, int newHeight) {
     screenTextureWidth = newWidth;
     screenTextureHeight = newHeight;
     recreate_frame_buffer_object();
-    verticesDataDirty = true;
 }
 
 SEShaderInstance* se_frame_buffer_get_screen_shader() {

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -21,7 +21,6 @@ static int screenTextureHeight = 600;
 static int resolutionWidth = 800;
 static int resolutionHeight = 600;
 static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 }, .window = { .w = 800, .h = 600 } };
-static bool verticesDataDirty = false;
 static bool maintainAspectRatio = true;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight) {
@@ -53,13 +52,16 @@ FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, 
 
     const FrameBufferViewportData data = {
         // TODO: Setting viewport position to something other than (0, 0) is not working for the renderer screen texture...
-//        .position = { .x = viewportX, .y = viewportY },
-        .position = { .x = 0, .y = 0 },
+        .position = { .x = viewportX, .y = viewportY },
         .size = { .w = viewportWidth, .h = viewportHeight },
         .window = { .w = windowWidth, .h = windowHeight }
     };
     cachedViewportData = data;
     return data;
+}
+
+FrameBufferViewportData* se_frame_buffer_get_cached_viewport_data() {
+    return &cachedViewportData;
 }
 
 bool recreate_frame_buffer_object() {
@@ -72,6 +74,8 @@ bool recreate_frame_buffer_object() {
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, screenTextureWidth, screenTextureHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorBuffer, 0);
     // Create renderbuffer object for depth and stencil attachment
     glGenRenderbuffers(1, &rbo);
@@ -87,44 +91,6 @@ bool recreate_frame_buffer_object() {
     return success;
 }
 
-void se_frame_buffer_update_vertices_buffer_data(bool bindBuffer) {
-    if (!verticesDataDirty) {
-        return;
-    }
-    const SEVector2 viewport = { .x = (float)cachedViewportData.position.x, .y = (float)cachedViewportData.position.y };
-    const SESize2D size = { .w = (float)cachedViewportData.size.w, .h = (float)cachedViewportData.size.h };
-    // Calculate texture coords
-//    const GLfloat sMin = (viewport.x) / size.w;
-//    const GLfloat sMax = (viewport.x + size.w) / size.w;
-//    const GLfloat tMin = (viewport.y) / size.h;
-//    const GLfloat tMax = (viewport.y + size.h) / size.h;
-
-    const GLfloat sMin = 0.0f;
-    const GLfloat sMax = 1.0f;
-    const GLfloat tMin = 0.0f;
-    const GLfloat tMax = 1.0f;
-
-    // Fills in the viewport but doesn't show entire screen texture
-    GLfloat vertices[] = {
-        // pos      // tex coords
-        -1.0f, 1.0f, sMin, tMax,
-            -1.0f, -1.0f, sMin, tMin,
-            1.0f, -1.0f, sMax, tMin,
-
-            -1.0f, 1.0f, sMin, tMax,
-            1.0f, -1.0f, sMax, tMin,
-            1.0f, 1.0f, sMax, tMax
-        };
-    if (bindBuffer) {
-        glBindBuffer(GL_ARRAY_BUFFER, screenVBO);
-    }
-    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-    if (bindBuffer) {
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-    }
-    verticesDataDirty = false;
-}
-
 bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight) {
     screenTextureWidth = inWindowWidth;
     screenTextureHeight = inWindowHeight;
@@ -136,7 +102,18 @@ bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inRes
     glGenBuffers(1, &screenVBO);
     glBindVertexArray(screenVAO);
     glBindBuffer(GL_ARRAY_BUFFER, screenVBO);
-    se_frame_buffer_update_vertices_buffer_data(false);
+    // Set buffer data
+    GLfloat vertices[] = {
+            // pos      // tex coords
+            -1.0f, 1.0f, 0.0f, 1.0f,
+            -1.0f, -1.0f, 0.0f, 0.0f,
+            1.0f, -1.0f, 1.0f, 0.0f,
+
+            -1.0f, 1.0f, 0.0f, 1.0f,
+            1.0f, -1.0f, 1.0f, 0.0f,
+            1.0f, 1.0f, 1.0f, 1.0f
+    };
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
     // position attribute
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(GLfloat), (GLvoid*) NULL);

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -21,7 +21,7 @@ static int screenTextureHeight = 600;
 static int resolutionWidth = 800;
 static int resolutionHeight = 600;
 static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 } };
-static bool maintainAspectRatio = true;
+static bool maintainAspectRatio = false;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight) {
     int framebufferWidth = windowWidth;
@@ -161,6 +161,10 @@ void se_frame_buffer_resize_texture(int newWidth, int newHeight) {
     screenTextureWidth = newWidth;
     screenTextureHeight = newHeight;
     recreate_frame_buffer_object();
+}
+
+void se_frame_buffer_set_maintain_aspect_ratio(bool shouldMaintainAspectRatio) {
+    maintainAspectRatio = shouldMaintainAspectRatio;
 }
 
 SEShaderInstance* se_frame_buffer_get_screen_shader() {

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -20,22 +20,59 @@ static int screenTextureWidth = 800;
 static int screenTextureHeight = 600;
 static int resolutionWidth = 800;
 static int resolutionHeight = 600;
+static bool maintainAspectRatio = false;
+
+typedef struct FrameBufferCreationData {
+    SESize2Di size;
+    SEVector2 offset;
+} FrameBufferCreationData;
+
+FrameBufferCreationData get_frame_buffer_size_data() {
+    FrameBufferCreationData creationData = {
+        .size = { .w = screenTextureWidth, .h = screenTextureHeight },
+        .offset = { .x = 0.0f, .y = 0.0f }
+    };
+    // TODO: Create enum for aspect ratio type and actually implement something that works...
+    if (maintainAspectRatio) {
+        const float windowAspectRatio = (float)screenTextureWidth / (float)screenTextureHeight;
+        const float resolutionAspectRatio = (float)resolutionWidth / (float)resolutionHeight;
+        if (windowAspectRatio != resolutionAspectRatio) {
+            float scaleFactor = 1.0f;
+            float offsetX = 0.0f;
+            float offsetY = 0.0f;
+            if (windowAspectRatio > resolutionAspectRatio) {
+                // If screen is wider than game resolution's width
+                scaleFactor = (float)screenTextureHeight / (float) resolutionHeight;
+                offsetX = ((float)screenTextureWidth - (float)resolutionWidth * scaleFactor) / 2.0f;
+            } else {
+                // If screen is taller than game resolution's height
+                scaleFactor = (float)screenTextureWidth / (float)resolutionWidth;
+                offsetY = ((float)screenTextureHeight - (float)resolutionHeight * scaleFactor) / 2.0f;
+            }
+            // Now update screen texture dimensions
+            creationData.size.w *= scaleFactor;
+            creationData.size.h *= scaleFactor;
+        }
+    }
+    return creationData;
+}
 
 bool recreate_frame_buffer_object() {
+    const FrameBufferCreationData creationData = get_frame_buffer_size_data();
     // Create Framebuffer
     glGenFramebuffers(1, &frameBuffer);
     glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
     // Create color attachment
     glGenTextures(1, &textureColorBuffer);
     glBindTexture(GL_TEXTURE_2D, textureColorBuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, screenTextureWidth, screenTextureHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, creationData.size.w, creationData.size.h, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorBuffer, 0);
     // Create renderbuffer object for depth and stencil attachment
     glGenRenderbuffers(1, &rbo);
     glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, screenTextureWidth, screenTextureHeight);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, creationData.size.w, creationData.size.h);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo);
     // Check if framebuffer is complete
     const bool success = glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -20,7 +20,7 @@ static int screenTextureWidth = 800;
 static int screenTextureHeight = 600;
 static int resolutionWidth = 800;
 static int resolutionHeight = 600;
-static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 } };
+static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 }, .window = { .w = 800, .h = 600 } };
 static bool verticesDataDirty = false;
 static bool maintainAspectRatio = true;
 
@@ -52,8 +52,11 @@ FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, 
     const int viewportHeight = framebufferHeight;
 
     const FrameBufferViewportData data = {
-        .position = { .x = viewportX, .y = viewportY },
-        .size = { .w = viewportWidth, .h = viewportHeight }
+        // TODO: Setting viewport position to something other than (0, 0) is not working for the renderer screen texture...
+//        .position = { .x = viewportX, .y = viewportY },
+        .position = { .x = 0, .y = 0 },
+        .size = { .w = viewportWidth, .h = viewportHeight },
+        .window = { .w = windowWidth, .h = windowHeight }
     };
     cachedViewportData = data;
     return data;
@@ -91,10 +94,15 @@ void se_frame_buffer_update_vertices_buffer_data(bool bindBuffer) {
     const SEVector2 viewport = { .x = (float)cachedViewportData.position.x, .y = (float)cachedViewportData.position.y };
     const SESize2D size = { .w = (float)cachedViewportData.size.w, .h = (float)cachedViewportData.size.h };
     // Calculate texture coords
-    const GLfloat sMin = (viewport.x) / size.w;
-    const GLfloat sMax = (viewport.x + size.w) / size.w;
-    const GLfloat tMin = (viewport.y) / size.h;
-    const GLfloat tMax = (viewport.y + size.h) / size.h;
+//    const GLfloat sMin = (viewport.x) / size.w;
+//    const GLfloat sMax = (viewport.x + size.w) / size.w;
+//    const GLfloat tMin = (viewport.y) / size.h;
+//    const GLfloat tMax = (viewport.y + size.h) / size.h;
+
+    const GLfloat sMin = 0.0f;
+    const GLfloat sMax = 1.0f;
+    const GLfloat tMin = 0.0f;
+    const GLfloat tMax = 1.0f;
 
     // Fills in the viewport but doesn't show entire screen texture
     GLfloat vertices[] = {
@@ -149,6 +157,7 @@ bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inRes
     };
     se_frame_buffer_set_screen_shader(&defaultScreenShader);
     verticesDataDirty = true;
+    se_frame_buffer_generate_viewport_data(inWindowWidth, inWindowHeight);
 
     hasBeenInitialized = true;
     return success;

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -18,6 +18,8 @@ static GLuint screenVBO = -1;
 
 static int screenTextureWidth = 800;
 static int screenTextureHeight = 600;
+static int resolutionWidth = 800;
+static int resolutionHeight = 600;
 
 bool recreate_frame_buffer_object() {
     // Create Framebuffer
@@ -44,9 +46,11 @@ bool recreate_frame_buffer_object() {
     return success;
 }
 
-bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight) {
+bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight) {
     screenTextureWidth = inWindowWidth;
     screenTextureHeight = inWindowHeight;
+    resolutionWidth = inResolutionWidth;
+    resolutionHeight = inResolutionHeight;
     // VAO & VBO
     GLfloat vertices[] = {
         // pos      // tex coords

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -24,13 +24,10 @@ static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y =
 static bool maintainAspectRatio = true;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight) {
-    int framebufferWidth = windowWidth; // Original framebuffer width
-    int framebufferHeight = windowHeight; // Original framebuffer height
+    int framebufferWidth = windowWidth;
+    int framebufferHeight = windowHeight;
 
-    // Calculate the aspect ratio of the game's resolution
     const float game_aspect_ratio = (float)resolutionWidth / (float)resolutionHeight;
-
-    // Calculate the aspect ratio of the window
     const float window_aspect_ratio = (float)windowWidth / (float)windowHeight;
 
     // Adjust the framebuffer width or height to match the window aspect ratio

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -20,71 +20,62 @@ static int screenTextureWidth = 800;
 static int screenTextureHeight = 600;
 static int resolutionWidth = 800;
 static int resolutionHeight = 600;
-static bool maintainAspectRatio = true;
+static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 } };
+static bool maintainAspectRatio = false;
 
-FrameBufferCreationData get_frame_buffer_size_data() {
-    FrameBufferCreationData creationData = {
-        .size = { .w = screenTextureWidth, .h = screenTextureHeight },
-        .offset = { .x = 0.0f, .y = 0.0f }
-    };
-    return creationData;
-}
-
-FrameBufferViewportData se_frame_buffer_get_viewport_data() {
-    int window_width = screenTextureWidth; // Example window width
-    int window_height = screenTextureHeight; // Example window height
-    int framebuffer_width = resolutionWidth; // Original framebuffer width
-    int framebuffer_height = resolutionHeight; // Original framebuffer height
+FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight) {
+    int framebufferWidth = resolutionWidth; // Original framebuffer width
+    int framebufferHeight = resolutionHeight; // Original framebuffer height
 
     // Calculate the aspect ratio of the game's resolution
-    const float game_aspect_ratio = (float)framebuffer_width / (float)framebuffer_height;
+    const float game_aspect_ratio = (float)framebufferWidth / (float)framebufferHeight;
 
     // Calculate the aspect ratio of the window
-    const float window_aspect_ratio = (float)window_width / (float)window_height;
+    const float window_aspect_ratio = (float)windowWidth / (float)windowHeight;
 
     // Adjust the framebuffer width or height to match the window aspect ratio
     if (maintainAspectRatio && game_aspect_ratio != window_aspect_ratio) {
-        framebuffer_height = (int)(window_width / game_aspect_ratio);
-        framebuffer_width = window_width;
-        if (framebuffer_height > window_height) {
-            framebuffer_height = window_height;
-            framebuffer_width = (int)(window_height * game_aspect_ratio);
+        framebufferHeight = (int)(windowWidth / game_aspect_ratio);
+        framebufferWidth = windowWidth;
+        if (framebufferHeight > windowHeight) {
+            framebufferHeight = windowHeight;
+            framebufferWidth = (int)(windowHeight * game_aspect_ratio);
         }
     } else {
-        framebuffer_width = window_width;
-        framebuffer_height = window_height;
+        framebufferWidth = windowWidth;
+        framebufferHeight = windowHeight;
     }
 
 
     // Calculate the viewport dimensions
-    const int viewport_x = (window_width - framebuffer_width) / 2;
-    const int viewport_y = (window_height - framebuffer_height) / 2;
-    const int viewport_width = framebuffer_width;
-    const int viewport_height = framebuffer_height;
+    const int viewportX = (windowWidth - framebufferWidth) / 2;
+    const int viewportY = (windowHeight - framebufferHeight) / 2;
+    const int viewportWidth = framebufferWidth;
+    const int viewportHeight = framebufferHeight;
 
     const FrameBufferViewportData data = {
-        .position = { .x = viewport_x, .y = viewport_y },
-        .size = { .w = viewport_width, .h = viewport_height }
+        .position = { .x = viewportX, .y = viewportY },
+        .size = { .w = viewportWidth, .h = viewportHeight }
     };
+    cachedViewportData = data;
     return data;
 }
 
 bool recreate_frame_buffer_object() {
-    const FrameBufferCreationData creationData = get_frame_buffer_size_data();
     // Create Framebuffer
     glGenFramebuffers(1, &frameBuffer);
     glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
     // Create color attachment
     glGenTextures(1, &textureColorBuffer);
     glBindTexture(GL_TEXTURE_2D, textureColorBuffer);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, creationData.size.w, creationData.size.h, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, screenTextureWidth, screenTextureHeight, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureColorBuffer, 0);
     // Create renderbuffer object for depth and stencil attachment
     glGenRenderbuffers(1, &rbo);
     glBindRenderbuffer(GL_RENDERBUFFER, rbo);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, creationData.size.w, creationData.size.h);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, screenTextureWidth, screenTextureHeight);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, rbo);
     // Check if framebuffer is complete
     const bool success = glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -33,13 +33,11 @@ FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, 
     // Adjust the framebuffer width or height to match the window aspect ratio
     if (maintainAspectRatio && game_aspect_ratio != window_aspect_ratio) {
         framebufferHeight = (int)(windowWidth / game_aspect_ratio);
-        framebufferWidth = windowWidth;
         if (framebufferHeight > windowHeight) {
             framebufferHeight = windowHeight;
             framebufferWidth = (int)(windowHeight * game_aspect_ratio);
         }
     }
-
 
     // Calculate the viewport dimensions
     const int viewportX = (windowWidth - framebufferWidth) / 2;

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -25,11 +25,11 @@ static bool verticesDataDirty = false;
 static bool maintainAspectRatio = true;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight) {
-    int framebufferWidth = resolutionWidth; // Original framebuffer width
-    int framebufferHeight = resolutionHeight; // Original framebuffer height
+    int framebufferWidth = windowWidth; // Original framebuffer width
+    int framebufferHeight = windowHeight; // Original framebuffer height
 
     // Calculate the aspect ratio of the game's resolution
-    const float game_aspect_ratio = (float)framebufferWidth / (float)framebufferHeight;
+    const float game_aspect_ratio = (float)resolutionWidth / (float)resolutionHeight;
 
     // Calculate the aspect ratio of the window
     const float window_aspect_ratio = (float)windowWidth / (float)windowHeight;
@@ -42,9 +42,6 @@ FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, 
             framebufferHeight = windowHeight;
             framebufferWidth = (int)(windowHeight * game_aspect_ratio);
         }
-    } else {
-        framebufferWidth = windowWidth;
-        framebufferHeight = windowHeight;
     }
 
 
@@ -91,14 +88,15 @@ void se_frame_buffer_update_vertices_buffer_data(bool bindBuffer) {
     if (!verticesDataDirty) {
         return;
     }
+    const SEVector2 viewport = { .x = (float)cachedViewportData.position.x, .y = (float)cachedViewportData.position.y };
+    const SESize2D size = { .w = (float)cachedViewportData.size.w, .h = (float)cachedViewportData.size.h };
     // Calculate texture coords
-    // S
-    const GLfloat sMin = ((float)cachedViewportData.position.x + 0.5f) / (float)cachedViewportData.size.w;
-    const GLfloat sMax = ((float)cachedViewportData.position.x + (float)cachedViewportData.size.w - 0.5f) / (float)cachedViewportData.size.w;
-    // T
-    const GLfloat tMin = ((float)cachedViewportData.position.y + 0.5f) / (float)cachedViewportData.size.h;
-    const GLfloat tMax = ((float)cachedViewportData.position.y + (float)cachedViewportData.size.h - 0.5f) / (float)cachedViewportData.size.h;
+    const GLfloat sMin = (viewport.x) / size.w;
+    const GLfloat sMax = (viewport.x + size.w) / size.w;
+    const GLfloat tMin = (viewport.y) / size.h;
+    const GLfloat tMax = (viewport.y + size.h) / size.h;
 
+    // Fills in the viewport but doesn't show entire screen texture
     GLfloat vertices[] = {
         // pos      // tex coords
         -1.0f, 1.0f, sMin, tMax,

--- a/seika/src/rendering/frame_buffer.c
+++ b/seika/src/rendering/frame_buffer.c
@@ -20,7 +20,7 @@ static int screenTextureWidth = 800;
 static int screenTextureHeight = 600;
 static int resolutionWidth = 800;
 static int resolutionHeight = 600;
-static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 }, .window = { .w = 800, .h = 600 } };
+static FrameBufferViewportData cachedViewportData = { .position = { .x = 0, .y = 0 }, .size = { .w = 800, .h = 600 } };
 static bool maintainAspectRatio = true;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight) {
@@ -51,10 +51,8 @@ FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, 
     const int viewportHeight = framebufferHeight;
 
     const FrameBufferViewportData data = {
-        // TODO: Setting viewport position to something other than (0, 0) is not working for the renderer screen texture...
         .position = { .x = viewportX, .y = viewportY },
-        .size = { .w = viewportWidth, .h = viewportHeight },
-        .window = { .w = windowWidth, .h = windowHeight }
+        .size = { .w = viewportWidth, .h = viewportHeight }
     };
     cachedViewportData = data;
     return data;
@@ -104,15 +102,15 @@ bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inRes
     glBindBuffer(GL_ARRAY_BUFFER, screenVBO);
     // Set buffer data
     GLfloat vertices[] = {
-            // pos      // tex coords
-            -1.0f, 1.0f, 0.0f, 1.0f,
+        // pos      // tex coords
+        -1.0f, 1.0f, 0.0f, 1.0f,
             -1.0f, -1.0f, 0.0f, 0.0f,
             1.0f, -1.0f, 1.0f, 0.0f,
 
             -1.0f, 1.0f, 0.0f, 1.0f,
             1.0f, -1.0f, 1.0f, 0.0f,
             1.0f, 1.0f, 1.0f, 1.0f
-    };
+        };
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
     // position attribute
     glEnableVertexAttribArray(0);

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -6,7 +6,7 @@ extern "C" {
 
 #include <stdbool.h>
 
-bool se_frame_buffer_initialize();
+bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight);
 void se_frame_buffer_finalize();
 void se_frame_buffer_bind();
 void se_frame_buffer_unbind();

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -6,6 +6,8 @@ extern "C" {
 
 #include <stdbool.h>
 
+#include "../math/se_math.h"
+
 bool se_frame_buffer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight);
 void se_frame_buffer_finalize();
 void se_frame_buffer_bind();
@@ -17,6 +19,20 @@ void se_frame_buffer_resize_texture(int newWidth, int newHeight);
 struct SEShaderInstance* se_frame_buffer_get_screen_shader();
 void se_frame_buffer_set_screen_shader(struct SEShaderInstance* shaderInstance);
 void se_frame_buffer_reset_to_default_screen_shader();
+
+typedef struct FrameBufferViewportData {
+    SEVector2i position;
+    SESize2Di size;
+} FrameBufferViewportData;
+
+FrameBufferViewportData se_frame_buffer_get_viewport_data();
+
+typedef struct FrameBufferCreationData {
+    SESize2Di size;
+    SEVector2 offset;
+} FrameBufferCreationData;
+
+FrameBufferCreationData get_frame_buffer_size_data();
 
 #ifdef __cplusplus
 }

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -23,6 +23,7 @@ void se_frame_buffer_reset_to_default_screen_shader();
 typedef struct FrameBufferViewportData {
     SEVector2i position;
     SESize2Di size;
+    SESize2Di window;
 } FrameBufferViewportData;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight);

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -23,7 +23,6 @@ void se_frame_buffer_reset_to_default_screen_shader();
 typedef struct FrameBufferViewportData {
     SEVector2i position;
     SESize2Di size;
-    SESize2Di window;
 } FrameBufferViewportData;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight);

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -15,6 +15,7 @@ void se_frame_buffer_unbind();
 unsigned int se_frame_buffer_get_color_buffer_texture();
 unsigned int se_frame_buffer_get_quad_vao();
 void se_frame_buffer_resize_texture(int newWidth, int newHeight);
+void se_frame_buffer_set_maintain_aspect_ratio(bool shouldMaintainAspectRatio);
 
 struct SEShaderInstance* se_frame_buffer_get_screen_shader();
 void se_frame_buffer_set_screen_shader(struct SEShaderInstance* shaderInstance);

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -27,8 +27,7 @@ typedef struct FrameBufferViewportData {
 } FrameBufferViewportData;
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight);
-
-void se_frame_buffer_update_vertices_buffer_data(bool bindBuffer);
+FrameBufferViewportData* se_frame_buffer_get_cached_viewport_data();
 
 #ifdef __cplusplus
 }

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -25,14 +25,7 @@ typedef struct FrameBufferViewportData {
     SESize2Di size;
 } FrameBufferViewportData;
 
-FrameBufferViewportData se_frame_buffer_get_viewport_data();
-
-typedef struct FrameBufferCreationData {
-    SESize2Di size;
-    SEVector2 offset;
-} FrameBufferCreationData;
-
-FrameBufferCreationData get_frame_buffer_size_data();
+FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight);
 
 #ifdef __cplusplus
 }

--- a/seika/src/rendering/frame_buffer.h
+++ b/seika/src/rendering/frame_buffer.h
@@ -27,6 +27,8 @@ typedef struct FrameBufferViewportData {
 
 FrameBufferViewportData se_frame_buffer_generate_viewport_data(int windowWidth, int windowHeight);
 
+void se_frame_buffer_update_vertices_buffer_data(bool bindBuffer);
+
 #ifdef __cplusplus
 }
 #endif

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -224,6 +224,9 @@ void se_renderer_process_and_flush_batches(const SEColor* backgroundColor) {
     glClearColor(backgroundColor->r, backgroundColor->g, backgroundColor->b, backgroundColor->a);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
+    FrameBufferViewportData* viewportData = se_frame_buffer_get_cached_viewport_data();
+    glViewport(0, 0, viewportData->size.w, viewportData->size.h);
+
     se_renderer_flush_batches();
 
 #ifdef SE_RENDER_TO_FRAMEBUFFER
@@ -232,7 +235,7 @@ void se_renderer_process_and_flush_batches(const SEColor* backgroundColor) {
     // Clear screen texture background
     static const SEColor screenBackgroundColor = { 0.0f, 0.0f, 0.0f, 1.0f };
     glClearColor(screenBackgroundColor.r, screenBackgroundColor.g, screenBackgroundColor.b, screenBackgroundColor.a);
-    glClear(GL_COLOR_BUFFER_BIT);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     // Draw screen texture from framebuffer
     SEShaderInstance* screenShaderInstance = se_frame_buffer_get_screen_shader();
     se_shader_use(screenShaderInstance->shader);
@@ -241,8 +244,8 @@ void se_renderer_process_and_flush_batches(const SEColor* backgroundColor) {
     renderer_set_shader_instance_params(screenShaderInstance);
 
     glBindVertexArray(se_frame_buffer_get_quad_vao());
-    // Update vertices
-    se_frame_buffer_update_vertices_buffer_data(true);
+    glViewport(viewportData->position.x, viewportData->position.y, viewportData->size.w, viewportData->size.h);
+
     glBindTexture(GL_TEXTURE_2D, se_frame_buffer_get_color_buffer_texture());	// use the color attachment texture as the texture of the quad plane
     glDrawArrays(GL_TRIANGLES, 0, 6);
 #endif

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -93,7 +93,7 @@ SE_STATIC_ARRAY_CREATE(RenderLayer, SE_RENDERER_MAX_Z_INDEX, render_layer_items)
 SE_STATIC_ARRAY_CREATE(int, SE_RENDERER_MAX_Z_INDEX, active_render_layer_items_indices);
 
 // Renderer
-void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight) {
+void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight, bool maintainAspectRatio) {
     resolutionWidth = (float) inResolutionWidth;
     resolutionHeight = (float) inResolutionHeight;
     glEnable(GL_CULL_FACE);
@@ -107,6 +107,7 @@ void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolut
 #ifdef SE_RENDER_TO_FRAMEBUFFER
     // Initialize framebuffer
     SE_ASSERT_FMT(se_frame_buffer_initialize(inWindowWidth, inWindowHeight, inResolutionWidth, inResolutionHeight), "Framebuffer didn't initialize!");
+    se_frame_buffer_set_maintain_aspect_ratio(maintainAspectRatio);
 #endif
     // Set initial data for render layer
     for (size_t i = 0; i < SE_RENDERER_MAX_Z_INDEX; i++) {

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -230,7 +230,7 @@ void se_renderer_process_and_flush_batches(const SEColor* backgroundColor) {
     se_frame_buffer_unbind();
 
     // Clear screen texture background
-    static const SEColor screenBackgroundColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+    static const SEColor screenBackgroundColor = { 0.0f, 0.0f, 0.0f, 1.0f };
     glClearColor(screenBackgroundColor.r, screenBackgroundColor.g, screenBackgroundColor.b, screenBackgroundColor.a);
     glClear(GL_COLOR_BUFFER_BIT);
     // Draw screen texture from framebuffer

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -130,7 +130,7 @@ void se_renderer_finalize() {
 }
 
 void se_renderer_update_window_size(int windowWidth, int windowHeight) {
-    const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data((int)windowWidth, (int)windowHeight);
+    const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data(windowWidth, windowHeight);
     glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
     SERenderContext* renderContext = se_render_context_get();
     renderContext->windowWidth = data.size.w;

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -100,7 +100,7 @@ void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolut
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     se_render_context_initialize();
-    se_renderer_update_window_size((float) inWindowWidth, (float) inWindowHeight);
+    se_renderer_update_window_size(inWindowWidth, inWindowHeight);
     sprite_renderer_initialize();
     font_renderer_initialize();
     se_shader_cache_initialize();
@@ -128,14 +128,14 @@ void se_renderer_finalize() {
 #endif
 }
 
-void se_renderer_update_window_size(float windowWidth, float windowHeight) {
-    const int width = (int) windowWidth;
-    const int height = (int) windowHeight;
+void se_renderer_update_window_size(int windowWidth, int windowHeight) {
+    const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data((int)windowWidth, (int)windowHeight);
+    glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
     SERenderContext* renderContext = se_render_context_get();
-    renderContext->windowWidth = width;
-    renderContext->windowHeight = height;
+    renderContext->windowWidth = data.size.w;
+    renderContext->windowHeight = data.size.h;
 #ifdef SE_RENDER_TO_FRAMEBUFFER
-    se_frame_buffer_resize_texture(width, height);
+    se_frame_buffer_resize_texture(data.size.w, data.size.h);
 #endif
 }
 

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -106,7 +106,7 @@ void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolut
     se_shader_cache_initialize();
 #ifdef SE_RENDER_TO_FRAMEBUFFER
     // Initialize framebuffer
-    SE_ASSERT_FMT(se_frame_buffer_initialize(inWindowWidth, inWindowHeight), "Framebuffer didn't initialize!");
+    SE_ASSERT_FMT(se_frame_buffer_initialize(inWindowWidth, inWindowHeight, inResolutionWidth, inResolutionHeight), "Framebuffer didn't initialize!");
 #endif
     // Set initial data for render layer
     for (size_t i = 0; i < SE_RENDERER_MAX_Z_INDEX; i++) {

--- a/seika/src/rendering/renderer.c
+++ b/seika/src/rendering/renderer.c
@@ -241,6 +241,8 @@ void se_renderer_process_and_flush_batches(const SEColor* backgroundColor) {
     renderer_set_shader_instance_params(screenShaderInstance);
 
     glBindVertexArray(se_frame_buffer_get_quad_vao());
+    // Update vertices
+    se_frame_buffer_update_vertices_buffer_data(true);
     glBindTexture(GL_TEXTURE_2D, se_frame_buffer_get_color_buffer_texture());	// use the color attachment texture as the texture of the quad plane
     glDrawArrays(GL_TRIANGLES, 0, 6);
 #endif

--- a/seika/src/rendering/renderer.h
+++ b/seika/src/rendering/renderer.h
@@ -15,7 +15,7 @@ extern "C" {
 
 void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight);
 void se_renderer_finalize();
-void se_renderer_update_window_size(float windowWidth, float windowHeight);
+void se_renderer_update_window_size(int windowWidth, int windowHeight);
 void se_renderer_set_sprite_shader_default_params(SEShader* shader);
 void se_renderer_queue_sprite_draw_call(SETexture* texture, SERect2 sourceRect, SESize2D destSize, SEColor color, bool flipH, bool flipV, SETransformModel2D* globalTransform, int zIndex, SEShaderInstance* shaderInstance);
 void se_renderer_queue_font_draw_call(SEFont* font, const char* text, float x, float y, float scale, SEColor color, int zIndex);

--- a/seika/src/rendering/renderer.h
+++ b/seika/src/rendering/renderer.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #define SE_RENDERER_MAX_Z_INDEX 200
 
-void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight);
+void se_renderer_initialize(int inWindowWidth, int inWindowHeight, int inResolutionWidth, int inResolutionHeight, bool maintainAspectRatio);
 void se_renderer_finalize();
 void se_renderer_update_window_size(int windowWidth, int windowHeight);
 void se_renderer_set_sprite_shader_default_params(SEShader* shader);

--- a/seika/src/seika.c
+++ b/seika/src/seika.c
@@ -12,6 +12,7 @@
 #include "audio/audio_manager.h"
 #include "asset/asset_file_loader.h"
 #include "asset/asset_manager.h"
+#include "rendering/frame_buffer.h"
 
 bool initialize_sdl();
 bool initialize_rendering(const char* title, int windowWidth, int windowHeight, int resolutionWidth, int resolutionHeight);
@@ -143,7 +144,10 @@ void sf_process_inputs() {
                 const Sint32 windowWidth = event.window.data1;
                 const Sint32 windowHeight = event.window.data2;
                 se_renderer_update_window_size((float) windowWidth, (float) windowHeight);
-                glViewport(0, 0, windowWidth, windowHeight);
+                const FrameBufferViewportData data = se_frame_buffer_get_viewport_data();
+                glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
+                se_renderer_update_window_size((float) data.size.w, (float) data.size.h);
+//                glViewport(0, 0, windowWidth, windowHeight);
                 break;
             }
             }

--- a/seika/src/seika.c
+++ b/seika/src/seika.c
@@ -143,10 +143,10 @@ void sf_process_inputs() {
             case SDL_WINDOWEVENT_SIZE_CHANGED: {
                 const Sint32 windowWidth = event.window.data1;
                 const Sint32 windowHeight = event.window.data2;
-                se_renderer_update_window_size((float) windowWidth, (float) windowHeight);
-                const FrameBufferViewportData data = se_frame_buffer_get_viewport_data();
+//                se_renderer_update_window_size((float) windowWidth, (float) windowHeight);
+                const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data(windowWidth, windowHeight);
                 glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
-                se_renderer_update_window_size((float) data.size.w, (float) data.size.h);
+                se_renderer_update_window_size((float)data.size.w, (float)data.size.h);
 //                glViewport(0, 0, windowWidth, windowHeight);
                 break;
             }

--- a/seika/src/seika.c
+++ b/seika/src/seika.c
@@ -14,7 +14,7 @@
 #include "asset/asset_manager.h"
 
 bool initialize_sdl();
-bool initialize_rendering(const char* title, int windowWidth, int windowHeight, int resolutionWidth, int resolutionHeight);
+bool initialize_rendering(const char* title, int windowWidth, int windowHeight, int resolutionWidth, int resolutionHeight, bool maintainAspectRatio);
 bool initialize_audio();
 bool initialize_input(const char* controllerDBFilePath);
 
@@ -23,7 +23,7 @@ static SDL_GLContext openGlContext;
 static bool isRunning = false;
 
 bool sf_initialize_simple(const char* title, int windowWidth, int windowHeight) {
-    return sf_initialize(title, windowWidth, windowHeight, windowWidth, windowHeight, NULL);
+    return sf_initialize(title, windowWidth, windowHeight, windowWidth, windowHeight, false, NULL);
 }
 
 bool sf_initialize(const char* title,
@@ -31,6 +31,7 @@ bool sf_initialize(const char* title,
                    int windowHeight,
                    int resolutionWidth,
                    int resolutionHeight,
+                   bool maintainAspectRatio,
                    const char* controllerDBFilePath) {
     if (isRunning) {
         return false;
@@ -46,7 +47,7 @@ bool sf_initialize(const char* title,
         se_logger_error("Failed to initialize sdl!");
         return false;
     }
-    if (!initialize_rendering(title, windowWidth, windowHeight, resolutionWidth, resolutionHeight)) {
+    if (!initialize_rendering(title, windowWidth, windowHeight, resolutionWidth, resolutionHeight, maintainAspectRatio)) {
         se_logger_error("Failed to initialize rendering!");
         return false;
     }
@@ -74,7 +75,7 @@ bool initialize_sdl() {
     return true;
 }
 
-bool initialize_rendering(const char* title, int windowWidth, int windowHeight, int resolutionWidth, int resolutionHeight) {
+bool initialize_rendering(const char* title, int windowWidth, int windowHeight, int resolutionWidth, int resolutionHeight, bool maintainAspectRatio) {
     // OpenGL attributes
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
@@ -112,7 +113,7 @@ bool initialize_rendering(const char* title, int windowWidth, int windowHeight, 
         return false;
     }
 
-    se_renderer_initialize(windowWidth, windowHeight, resolutionWidth, resolutionHeight);
+    se_renderer_initialize(windowWidth, windowHeight, resolutionWidth, resolutionHeight, maintainAspectRatio);
     return true;
 }
 

--- a/seika/src/seika.c
+++ b/seika/src/seika.c
@@ -143,11 +143,9 @@ void sf_process_inputs() {
             case SDL_WINDOWEVENT_SIZE_CHANGED: {
                 const Sint32 windowWidth = event.window.data1;
                 const Sint32 windowHeight = event.window.data2;
-//                se_renderer_update_window_size((float) windowWidth, (float) windowHeight);
                 const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data(windowWidth, windowHeight);
                 se_renderer_update_window_size((float)data.size.w, (float)data.size.h);
                 glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
-//                glViewport(0, 0, windowWidth, windowHeight);
                 break;
             }
             }

--- a/seika/src/seika.c
+++ b/seika/src/seika.c
@@ -145,8 +145,8 @@ void sf_process_inputs() {
                 const Sint32 windowHeight = event.window.data2;
 //                se_renderer_update_window_size((float) windowWidth, (float) windowHeight);
                 const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data(windowWidth, windowHeight);
-                glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
                 se_renderer_update_window_size((float)data.size.w, (float)data.size.h);
+                glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
 //                glViewport(0, 0, windowWidth, windowHeight);
                 break;
             }

--- a/seika/src/seika.c
+++ b/seika/src/seika.c
@@ -12,7 +12,6 @@
 #include "audio/audio_manager.h"
 #include "asset/asset_file_loader.h"
 #include "asset/asset_manager.h"
-#include "rendering/frame_buffer.h"
 
 bool initialize_sdl();
 bool initialize_rendering(const char* title, int windowWidth, int windowHeight, int resolutionWidth, int resolutionHeight);
@@ -143,9 +142,7 @@ void sf_process_inputs() {
             case SDL_WINDOWEVENT_SIZE_CHANGED: {
                 const Sint32 windowWidth = event.window.data1;
                 const Sint32 windowHeight = event.window.data2;
-                const FrameBufferViewportData data = se_frame_buffer_generate_viewport_data(windowWidth, windowHeight);
-                se_renderer_update_window_size((float)data.size.w, (float)data.size.h);
-                glViewport(data.position.x, data.position.y, data.size.w, data.size.h);
+                se_renderer_update_window_size(windowWidth, windowHeight);
                 break;
             }
             }

--- a/seika/src/seika.h
+++ b/seika/src/seika.h
@@ -8,6 +8,7 @@ bool sf_initialize(const char* title,
                    int windowHeight,
                    int resolutionWidth,
                    int resolutionHeight,
+                   bool maintainAspectRatio,
                    const char* controllerDBFilePath);
 void sf_process_inputs();
 void sf_update();

--- a/test_games/cardboard_fighter/project.ccfg
+++ b/test_games/cardboard_fighter/project.ccfg
@@ -4,9 +4,11 @@
     "window_height": 600,
     "resolution_width": 800,
     "resolution_height": 600,
+    "maintain_aspect_ratio": true,
     "target_fps": 66,
     "initial_node_path": "nodes/title_screen.cscn",
     "colliders_visible": false,
+    "version": "0.0.1",
     "assets": {
         "audio_sources": [
             {


### PR DESCRIPTION
- Can now maintain aspect ratio in window.  Also added property to configure this setting within the editor.
- Fixed editor bug where it didn't respect a node's z_index when rendering in scene view.
- Default `Collider2D` node color doesn't have full alpha value in the editor.