### PR TITLE
Can update origin for Sprite and AnimatedSprite at runtime

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: run pvs studio
         run: |
-          pvs-studio-analyzer analyze -f builds/compile_commands.json -j -e include -e docs -e assets -e test_games
+          pvs-studio-analyzer analyze -f builds/compile_commands.json -j -e include -e docs -e assets -e test_games --disableLicenseExpirationCheck
 
       - name: convert pvs studio report
         run: |

--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ Technically any game type will be able to be made with the engine.  But these ar
   * [MiniAudio](https://github.com/mackron/miniaudio) - Audio
   * [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) (3.10) - Scripting
   * [Unity](https://github.com/ThrowTheSwitch/Unity) - Testing
+  * [PVS-Studio](https://pvs-studio.com/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) - static analyzer for C code.
 * Editor
-    * [C++](https://en.wikipedia.org/wiki/C%2B%2B) (c++20) - Editor Core
-    * [SDL2](https://github.com/libsdl-org/SDL) - Windowing, inputs
-    * [ImGui](https://github.com/ocornut/imgui) - GUI Library
-    * [ImPlot](https://github.com/epezent/implot) - Plotting Library (Used with ImGui)
-    * [MiniAudio](https://github.com/mackron/miniaudio) - Audio
-    * [Catch2](https://github.com/catchorg/Catch2) - Testing
+  * [C++](https://en.wikipedia.org/wiki/C%2B%2B) (c++20) - Editor Core
+  * [SDL2](https://github.com/libsdl-org/SDL) - Windowing, inputs
+  * [ImGui](https://github.com/ocornut/imgui) - GUI Library
+  * [ImPlot](https://github.com/epezent/implot) - Plotting Library (Used with ImGui)
+  * [MiniAudio](https://github.com/mackron/miniaudio) - Audio
+  * [Catch2](https://github.com/catchorg/Catch2) - Testing
+  * [PVS-Studio](https://pvs-studio.com/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) - static analyzer for C++ code.
+* All
 
 ## Building
 

--- a/crescent_py_api/crescent_api.py
+++ b/crescent_py_api/crescent_api.py
@@ -1206,6 +1206,17 @@ class Sprite(Node2D):
         )
 
     @property
+    def origin(self) -> Vector2:
+        x, y = crescent_api_internal.sprite_get_origin(entity_id=self.entity_id)
+        return Vector2(x, y)
+
+    @origin.setter
+    def origin(self, value: Vector2) -> None:
+        crescent_api_internal.sprite_set_origin(
+            entity_id=self.entity_id, x=value.x, y=value.y
+        )
+
+    @property
     def shader_instance(self) -> Optional[ShaderInstance]:
         shader_instance_id = crescent_api_internal.sprite_get_shader_instance(
             entity_id=self.entity_id
@@ -1295,6 +1306,19 @@ class AnimatedSprite(Node2D):
             g=color.g,
             b=color.b,
             a=color.a,
+        )
+
+    @property
+    def origin(self) -> Vector2:
+        x, y = crescent_api_internal.animated_sprite_get_origin(
+            entity_id=self.entity_id
+        )
+        return Vector2(x, y)
+
+    @origin.setter
+    def origin(self, value: Vector2) -> None:
+        crescent_api_internal.animated_sprite_set_origin(
+            entity_id=self.entity_id, x=value.x, y=value.y
         )
 
     @property

--- a/crescent_py_api/crescent_api_internal.py
+++ b/crescent_py_api/crescent_api_internal.py
@@ -500,6 +500,14 @@ def sprite_get_flip_v(entity_id: int) -> bool:
     return False
 
 
+def sprite_set_origin(entity_id: int, x: float, y: float) -> None:
+    pass
+
+
+def sprite_get_origin(entity_id: int) -> Tuple[float, float]:
+    pass
+
+
 def sprite_get_shader_instance(entity_id: int) -> int:
     return 0
 
@@ -554,6 +562,14 @@ def animated_sprite_set_flip_v(entity_id: int, flip_v: bool) -> None:
 
 def animated_sprite_get_flip_v(entity_id: int) -> bool:
     return False
+
+
+def animated_sprite_set_origin(entity_id: int, x: float, y: float) -> None:
+    pass
+
+
+def animated_sprite_get_origin(entity_id: int) -> Tuple[float, float]:
+    pass
 
 
 def animated_sprite_get_shader_instance(entity_id: int) -> int:

--- a/engine/src/core/scene/scene_manager.c
+++ b/engine/src/core/scene/scene_manager.c
@@ -147,19 +147,21 @@ void cre_scene_manager_process_queued_deletion_entities() {
         // Remove entity from systems
         cre_ec_system_remove_entity_from_all_systems(entityToDelete);
         // Remove shader instance if applicable
-        SpriteComponent* spriteComponent = cre_component_manager_get_component_unchecked(entityToDelete,
-                                           CreComponentDataIndex_SPRITE);
+        SpriteComponent* spriteComponent = cre_component_manager_get_component_unchecked(entityToDelete, CreComponentDataIndex_SPRITE);
         if (spriteComponent != NULL && spriteComponent->shaderInstanceId != SE_SHADER_INSTANCE_INVALID_ID) {
             SEShaderInstance* shaderInstance = se_shader_cache_get_instance(spriteComponent->shaderInstanceId);
-            se_shader_cache_remove_instance(spriteComponent->shaderInstanceId);
-            SE_MEM_FREE(shaderInstance);
+            if (shaderInstance) {
+                se_shader_cache_remove_instance(spriteComponent->shaderInstanceId);
+                se_shader_instance_destroy(shaderInstance);
+            }
         }
-        AnimatedSpriteComponent* animatedSpriteComponent = cre_component_manager_get_component_unchecked(entityToDelete,
-                CreComponentDataIndex_ANIMATED_SPRITE);
+        AnimatedSpriteComponent* animatedSpriteComponent = cre_component_manager_get_component_unchecked(entityToDelete, CreComponentDataIndex_ANIMATED_SPRITE);
         if (animatedSpriteComponent != NULL && animatedSpriteComponent->shaderInstanceId != SE_SHADER_INSTANCE_INVALID_ID) {
             SEShaderInstance* shaderInstance = se_shader_cache_get_instance(animatedSpriteComponent->shaderInstanceId);
-            se_shader_cache_remove_instance(animatedSpriteComponent->shaderInstanceId);
-            SE_MEM_FREE(shaderInstance);
+            if (shaderInstance) {
+                se_shader_cache_remove_instance(animatedSpriteComponent->shaderInstanceId);
+                se_shader_instance_destroy(shaderInstance);
+            }
         }
         // Remove all components
         cre_component_manager_remove_all_components(entityToDelete);

--- a/engine/src/core/scripting/python/cre_py_api_module.c
+++ b/engine/src/core/scripting/python/cre_py_api_module.c
@@ -1392,6 +1392,28 @@ PyObject* cre_py_api_sprite_get_modulate(PyObject* self, PyObject* args, PyObjec
     return NULL;
 }
 
+PyObject* cre_py_api_sprite_set_origin(PyObject* self, PyObject* args, PyObject* kwargs) {
+    CreEntity entity;
+    float x;
+    float y;
+    if (PyArg_ParseTupleAndKeywords(args, kwargs, "iff", crePyApiNode2DSetXYKWList, &entity, &x, &y)) {
+        SpriteComponent* spriteComponent = (SpriteComponent*) cre_component_manager_get_component(entity, CreComponentDataIndex_SPRITE);
+        spriteComponent->origin.x = x;
+        spriteComponent->origin.y = y;
+        Py_RETURN_NONE;
+    }
+    return NULL;
+}
+
+PyObject* cre_py_api_sprite_get_origin(PyObject* self, PyObject* args, PyObject* kwargs) {
+    CreEntity entity;
+    if (PyArg_ParseTupleAndKeywords(args, kwargs, "i", crePyApiGenericGetEntityKWList, &entity)) {
+        const SpriteComponent* spriteComponent = (SpriteComponent*) cre_component_manager_get_component(entity, CreComponentDataIndex_SPRITE);
+        return Py_BuildValue("(ff)", spriteComponent->origin.x, spriteComponent->origin.y);
+    }
+    return NULL;
+}
+
 PyObject* cre_py_api_sprite_set_shader_instance(PyObject* self, PyObject* args, PyObject* kwargs) {
     CreEntity entity;
     SEShaderInstanceId shaderInstanceId;
@@ -1582,12 +1604,33 @@ PyObject* cre_py_api_animated_sprite_get_modulate(PyObject* self, PyObject* args
     return NULL;
 }
 
+PyObject* cre_py_api_animated_sprite_set_origin(PyObject* self, PyObject* args, PyObject* kwargs) {
+    CreEntity entity;
+    float x;
+    float y;
+    if (PyArg_ParseTupleAndKeywords(args, kwargs, "iff", crePyApiNode2DSetXYKWList, &entity, &x, &y)) {
+        AnimatedSpriteComponent* animatedSpriteComponent = (AnimatedSpriteComponent *) cre_component_manager_get_component(entity, CreComponentDataIndex_ANIMATED_SPRITE);
+        animatedSpriteComponent->origin.x = x;
+        animatedSpriteComponent->origin.y = y;
+        Py_RETURN_NONE;
+    }
+    return NULL;
+}
+
+PyObject* cre_py_api_animated_sprite_get_origin(PyObject* self, PyObject* args, PyObject* kwargs) {
+    CreEntity entity;
+    if (PyArg_ParseTupleAndKeywords(args, kwargs, "i", crePyApiGenericGetEntityKWList, &entity)) {
+        const AnimatedSpriteComponent* animatedSpriteComponent = (AnimatedSpriteComponent *) cre_component_manager_get_component(entity, CreComponentDataIndex_ANIMATED_SPRITE);
+        return Py_BuildValue("(ff)", animatedSpriteComponent->origin.x, animatedSpriteComponent->origin.y);
+    }
+    return NULL;
+}
+
 PyObject* cre_py_api_animated_sprite_set_shader_instance(PyObject* self, PyObject* args, PyObject* kwargs) {
     CreEntity entity;
     SEShaderInstanceId shaderInstanceId;
     if (PyArg_ParseTupleAndKeywords(args, kwargs, "ii", crePyApiGenericSetShaderInstanceKWList, &entity, &shaderInstanceId)) {
-        AnimatedSpriteComponent* animatedSpriteComponent = (AnimatedSpriteComponent *) cre_component_manager_get_component(
-                    entity, CreComponentDataIndex_ANIMATED_SPRITE);
+        AnimatedSpriteComponent* animatedSpriteComponent = (AnimatedSpriteComponent *) cre_component_manager_get_component(entity, CreComponentDataIndex_ANIMATED_SPRITE);
         animatedSpriteComponent->shaderInstanceId = shaderInstanceId;
         SEShaderInstance* shaderInstance = se_shader_cache_get_instance(animatedSpriteComponent->shaderInstanceId);
         se_renderer_set_sprite_shader_default_params(shaderInstance->shader);

--- a/engine/src/core/scripting/python/cre_py_api_module.h
+++ b/engine/src/core/scripting/python/cre_py_api_module.h
@@ -138,6 +138,8 @@ PyObject* cre_py_api_sprite_set_flip_v(PyObject* self, PyObject* args, PyObject*
 PyObject* cre_py_api_sprite_get_flip_v(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_sprite_set_modulate(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_sprite_get_modulate(PyObject* self, PyObject* args, PyObject* kwargs);
+PyObject* cre_py_api_sprite_set_origin(PyObject* self, PyObject* args, PyObject* kwargs);
+PyObject* cre_py_api_sprite_get_origin(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_sprite_set_shader_instance(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_sprite_get_shader_instance(PyObject* self, PyObject* args, PyObject* kwargs);
 
@@ -152,6 +154,8 @@ PyObject* cre_py_api_animated_sprite_set_flip_v(PyObject* self, PyObject* args, 
 PyObject* cre_py_api_animated_sprite_get_flip_v(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_animated_sprite_set_modulate(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_animated_sprite_get_modulate(PyObject* self, PyObject* args, PyObject* kwargs);
+PyObject* cre_py_api_animated_sprite_set_origin(PyObject* self, PyObject* args, PyObject* kwargs);
+PyObject* cre_py_api_animated_sprite_get_origin(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_animated_sprite_set_shader_instance(PyObject* self, PyObject* args, PyObject* kwargs);
 PyObject* cre_py_api_animated_sprite_get_shader_instance(PyObject* self, PyObject* args, PyObject* kwargs);
 
@@ -637,6 +641,14 @@ static struct PyMethodDef crePyApiMethods[] = {
         METH_VARARGS | METH_KEYWORDS, "Gets the sprite's modulate."
     },
     {
+        "sprite_set_origin", (PyCFunction) cre_py_api_sprite_set_origin,
+        METH_VARARGS | METH_KEYWORDS, "Sets the sprite's origin."
+    },
+    {
+        "sprite_get_origin", (PyCFunction) cre_py_api_sprite_get_origin,
+        METH_VARARGS | METH_KEYWORDS, "Gets the sprite's origin."
+    },
+    {
         "sprite_set_shader_instance", (PyCFunction) cre_py_api_sprite_set_shader_instance,
         METH_VARARGS | METH_KEYWORDS, "Sets the shader instance for the sprite."
     },
@@ -684,6 +696,14 @@ static struct PyMethodDef crePyApiMethods[] = {
     {
         "animated_sprite_get_modulate", (PyCFunction) cre_py_api_animated_sprite_get_modulate,
         METH_VARARGS | METH_KEYWORDS, "Gets the animated sprite's modulate."
+    },
+    {
+        "animated_sprite_set_origin", (PyCFunction) cre_py_api_animated_sprite_set_origin,
+        METH_VARARGS | METH_KEYWORDS, "Sets the animated sprite's origin."
+    },
+    {
+        "animated_sprite_get_origin", (PyCFunction) cre_py_api_animated_sprite_get_origin,
+        METH_VARARGS | METH_KEYWORDS, "Gets the animated sprite's origin."
     },
     {
         "animated_sprite_set_shader_instance", (PyCFunction) cre_py_api_animated_sprite_set_shader_instance,

--- a/engine/src/core/scripting/python/crescent_api_source.h
+++ b/engine/src/core/scripting/python/crescent_api_source.h
@@ -1243,6 +1243,17 @@
 "        )\n"\
 "\n"\
 "    @property\n"\
+"    def origin(self) -> Vector2:\n"\
+"        x, y = crescent_api_internal.sprite_get_origin(entity_id=self.entity_id)\n"\
+"        return Vector2(x, y)\n"\
+"\n"\
+"    @origin.setter\n"\
+"    def origin(self, value: Vector2) -> None:\n"\
+"        crescent_api_internal.sprite_set_origin(\n"\
+"            entity_id=self.entity_id, x=value.x, y=value.y\n"\
+"        )\n"\
+"\n"\
+"    @property\n"\
 "    def shader_instance(self) -> Optional[ShaderInstance]:\n"\
 "        shader_instance_id = crescent_api_internal.sprite_get_shader_instance(\n"\
 "            entity_id=self.entity_id\n"\
@@ -1332,6 +1343,19 @@
 "            g=color.g,\n"\
 "            b=color.b,\n"\
 "            a=color.a,\n"\
+"        )\n"\
+"\n"\
+"    @property\n"\
+"    def origin(self) -> Vector2:\n"\
+"        x, y = crescent_api_internal.animated_sprite_get_origin(\n"\
+"            entity_id=self.entity_id\n"\
+"        )\n"\
+"        return Vector2(x, y)\n"\
+"\n"\
+"    @origin.setter\n"\
+"    def origin(self, value: Vector2) -> None:\n"\
+"        crescent_api_internal.animated_sprite_set_origin(\n"\
+"            entity_id=self.entity_id, x=value.x, y=value.y\n"\
 "        )\n"\
 "\n"\
 "    @property\n"\

--- a/seika/src/data_structures/se_spatial_hash_map.h
+++ b/seika/src/data_structures/se_spatial_hash_map.h
@@ -4,7 +4,7 @@
 #include "se_hash_map.h"
 
 #define SE_SPATIAL_HASH_GRID_SPACE_ENTITY_LIMIT 32
-#define SE_SPATIAL_HASH_GRID_MAX_COLLISIONS 8
+#define SE_SPATIAL_HASH_GRID_MAX_COLLISIONS 16
 
 // Note: Spatial hash expects rectangles that have 0 rotation
 


### PR DESCRIPTION
- Can update origin for `Sprite` and `AnimatedSprite` at runtime
- Bug fix for shader instance deletion when a `Sprite` and `AnimatedSprite` leaves the scene.